### PR TITLE
(feat) Option to insert multiple images

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ lib
 lint-staged.config.js
 package.config.ts
 *.js
+dist

--- a/src/components/Browser/index.tsx
+++ b/src/components/Browser/index.tsx
@@ -28,6 +28,7 @@ type Props = {
   onClose?: AssetSourceComponentProps['onClose']
   onSelect?: AssetSourceComponentProps['onSelect']
   selectedAssets?: AssetSourceComponentProps['selectedAssets']
+  selectionType?: AssetSourceComponentProps['selectionType'] | 'multiple'
 }
 
 const BrowserContent = ({onClose}: {onClose?: AssetSourceComponentProps['onClose']}) => {
@@ -140,6 +141,7 @@ const Browser = (props: Props) => {
       client={client}
       document={props?.document}
       selectedAssets={props?.selectedAssets}
+      selectionType={props?.selectionType}
     >
       <ThemeProvider scheme={scheme} theme={studioTheme}>
         <ToastProvider>

--- a/src/components/CardAsset/index.tsx
+++ b/src/components/CardAsset/index.tsx
@@ -97,6 +97,7 @@ const CardAsset = (props: Props) => {
   const dispatch = useDispatch()
   const lastPicked = useTypedSelector(state => state.assets.lastPicked)
   const item = useTypedSelector(state => selectAssetById(state, id))
+  const selectionType = useTypedSelector(state => state.selectionType)
 
   const asset = item?.asset
   const error = item?.error
@@ -115,7 +116,7 @@ const CardAsset = (props: Props) => {
   const handleAssetClick = (e: MouseEvent<HTMLDivElement>) => {
     e.stopPropagation()
 
-    if (onSelect) {
+    if (onSelect && selectionType !== 'multiple') {
       onSelect([
         {
           kind: 'assetDocumentId',
@@ -136,7 +137,7 @@ const CardAsset = (props: Props) => {
   const handleContextActionClick = (e: MouseEvent) => {
     e.stopPropagation()
 
-    if (onSelect) {
+    if (onSelect && selectionType !== 'multiple') {
       dispatch(dialogActions.showAssetEdit({assetId: asset._id}))
     } else if (shiftPressed.current && !picked) {
       dispatch(assetsActions.pickRange({startId: lastPicked || asset._id, endId: asset._id}))
@@ -224,7 +225,7 @@ const CardAsset = (props: Props) => {
           scheme={scheme}
           style={{opacity: opacityContainer}}
         >
-          {onSelect ? (
+          {onSelect && selectionType !== 'multiple' ? (
             <EditIcon
               style={{
                 flexShrink: 0,

--- a/src/components/PickedBar/index.tsx
+++ b/src/components/PickedBar/index.tsx
@@ -1,6 +1,6 @@
 import {Box, Button, Flex, Label} from '@sanity/ui'
 import pluralize from 'pluralize'
-import React from 'react'
+import React, {Fragment} from 'react'
 import {useDispatch} from 'react-redux'
 import {useColorScheme} from 'sanity'
 import {PANEL_HEIGHT} from '../../constants'
@@ -8,8 +8,11 @@ import useTypedSelector from '../../hooks/useTypedSelector'
 import {assetsActions, selectAssetsPicked} from '../../modules/assets'
 import {dialogActions} from '../../modules/dialog'
 import {getSchemeColor} from '../../utils/getSchemeColor'
+import {useAssetSourceActions} from '../../contexts/AssetSourceDispatchContext'
 
 const PickedBar = () => {
+  const selectionType = useTypedSelector(state => state.selectionType)
+  const {onSelect} = useAssetSourceActions()
   const {scheme} = useColorScheme()
 
   // Redux
@@ -23,6 +26,18 @@ const PickedBar = () => {
 
   const handleDeletePicked = () => {
     dispatch(dialogActions.showConfirmDeleteAssets({assets: assetsPicked}))
+  }
+
+  const handleInsertPicked = () => {
+    if (!onSelect) {
+      // This should never happen, since the rendering logic makes sure onSelect is defined
+      console.error('onSelect is not defined')
+      return
+    }
+
+    const assetIds = assetsPicked.map(({asset}) => asset._id)
+    const onSelectItems = assetIds.map(id => ({kind: 'assetDocumentId' as const, value: id}))
+    onSelect(onSelectItems)
   }
 
   if (assetsPicked.length === 0) {
@@ -48,27 +63,35 @@ const PickedBar = () => {
           </Label>
         </Box>
 
-        {/* Deselect button */}
-        <Button
-          mode="bleed"
-          onClick={handlePickClear}
-          padding={2}
-          style={{background: 'none', boxShadow: 'none'}}
-          tone="default"
-        >
-          <Label size={0}>Deselect</Label>
-        </Button>
+        {onSelect && selectionType === 'multiple' ? (
+          <Fragment>
+            <Button tone="primary" onClick={handleInsertPicked} padding={2}>
+              <Label size={0}>Insert images</Label>
+            </Button>
+          </Fragment>
+        ) : (
+          <Fragment>
+            <Button
+              mode="bleed"
+              onClick={handlePickClear}
+              padding={2}
+              style={{background: 'none', boxShadow: 'none'}}
+              tone="default"
+            >
+              <Label size={0}>Deselect</Label>
+            </Button>
 
-        {/* Delete button */}
-        <Button
-          mode="bleed"
-          onClick={handleDeletePicked}
-          padding={2}
-          style={{background: 'none', boxShadow: 'none'}}
-          tone="critical"
-        >
-          <Label size={0}>Delete</Label>
-        </Button>
+            <Button
+              mode="bleed"
+              onClick={handleDeletePicked}
+              padding={2}
+              style={{background: 'none', boxShadow: 'none'}}
+              tone="critical"
+            >
+              <Label size={0}>Delete</Label>
+            </Button>
+          </Fragment>
+        )}
       </Flex>
     </Flex>
   )

--- a/src/components/ReduxProvider/index.tsx
+++ b/src/components/ReduxProvider/index.tsx
@@ -18,6 +18,7 @@ type Props = {
   client: SanityClient
   document?: SanityDocument
   selectedAssets?: AssetSourceComponentProps['selectedAssets']
+  selectionType?: AssetSourceComponentProps['selectionType'] | 'multiple'
 }
 
 class ReduxProvider extends Component<Props> {
@@ -59,7 +60,8 @@ class ReduxProvider extends Component<Props> {
           assets: props.selectedAssets || [],
           document: props.document,
           documentAssetIds: props.document ? getDocumentAssetIds(props.document) : []
-        }
+        },
+        selectionType: props?.selectionType || 'single'
       }
     })
     epicMiddleware.run(rootEpic)

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -30,6 +30,7 @@ import dialogReducer, {
   dialogTagDeleteEpic
 } from './dialog'
 import selectedReducer from './selected'
+import selectionTypeReducer from './selectionType'
 import notificationsReducer, {
   notificationsAssetsDeleteErrorEpic,
   notificationsAssetsDeleteCompleteEpic,
@@ -109,6 +110,7 @@ const reducers = {
   notifications: notificationsReducer,
   search: searchReducer,
   selected: selectedReducer,
+  selectionType: selectionTypeReducer,
   tags: tagsReducer,
   uploads: uploadsReducer
 }

--- a/src/modules/selectionType/index.ts
+++ b/src/modules/selectionType/index.ts
@@ -1,0 +1,14 @@
+import {createSlice} from '@reduxjs/toolkit'
+import {AssetSourceComponentProps} from 'sanity'
+
+type SelectionTypeReducerState = AssetSourceComponentProps['selectionType'] | 'multiple'
+
+const initialState = 'single' as SelectionTypeReducerState
+
+const selectionTypeSlice = createSlice({
+  name: 'selectionType',
+  initialState,
+  reducers: {}
+})
+
+export default selectionTypeSlice.reducer


### PR DESCRIPTION
In my projects I always use the sanity-plugin-media, so thanks for creating it! In many of these projects I also run into that I want to insert multiple images at once in an image array (ie for a carousel or gallery). Searching around, I found that more people have this issue, see the Github issues below or the Sanity Slack:
- https://github.com/sanity-io/sanity/issues/4483
- https://github.com/sanity-io/sanity/issues/1804
- https://github.com/sanity-io/sanity-plugin-media/issues/85

In this pull request, I add the option to insert multiple images at once. By adding the `selectionType` 'multiple' option, you can determine that the asset source should pass multiple assets. This is not officially supported, but I figured that is where Sanity wishes to go with the `selectionType` property, since it currently only supports `"single"`.

In this PR I support `"multiple"`, without breaking- or changing any of the current functionality. If you do not pass the `selectionType="multiple"` it will work the same. 

To make this work in a project, you have to create a custom component that creates a AssetSourceComponent with the property `selectionType` set to `multiple`. I will pass mine as an example so you can see how this works:

```typescript
'use client';

import { AssetFromSource, StringInputProps, set, useFormBuilder } from 'sanity';
import { Button, Stack, Text } from '@sanity/ui';
import { FaRegImages } from 'react-icons/fa';
import React, { Fragment, MouseEventHandler, useCallback, useMemo, useState } from 'react';

export const MultipleImagesInputComponent = (properties: StringInputProps) => {
  const { onChange, value, renderDefault } = properties;
  const formBuilder = useFormBuilder();

  const [showAssetSource, setShowAssetSource] = useState(false);

  // I would love for this not to use internal but it is currently the only way I think.
  const AssetSourceComponent = useMemo(
    () => formBuilder?.__internal?.image?.assetSources[0]?.component,
    [formBuilder?.__internal?.image?.assetSources]
  );

  const handleAssetSourceClosed = useCallback(() => {
    setShowAssetSource(false);
  }, []);

  const handleSelectAssetFromSource = useCallback(
    (assetsFromSource: AssetFromSource[]) => {
      try {
        const assetReferences = assetsFromSource.map((asset) => ({
          _key: randomKey(),
          _type: 'image',
          asset: {
            _ref: asset.value,
            _type: 'reference',
          },
        }));

        const newValue = [...(value || []), ...assetReferences];
        onChange(set(newValue));
      } catch (error) {
        console.error(error);
      } finally {
        setShowAssetSource(false);
      }
    },
    [onChange, value]
  );

  const onMultipleImagesClick: MouseEventHandler<HTMLButtonElement> = useCallback(() => {
    setShowAssetSource(true);
  }, []);

  return (
    <Fragment>
      <Stack space={4}>
        {renderDefault(properties)}
        <Text size={2} muted align="center">
          💡 To upload multiple images, simply drag them on the list above.
        </Text>
        <Button
          onClick={onMultipleImagesClick}
          mode="ghost"
          icon={FaRegImages}
          text="Add multiple images from media"
        />
      </Stack>

      {showAssetSource && !!AssetSourceComponent ? (
        <AssetSourceComponent
          accept="image/*"
          assetType="image"
          onClose={handleAssetSourceClosed}
          onSelect={handleSelectAssetFromSource}
          selectedAssets={[]}
          selectionType="multiple" // This is where the magic happens
        />
      ) : undefined}
    </Fragment>
  );
};

function randomKey() {
  return Math.random().toString(36).slice(2);
}
```

I hope you will find this functionality useful. If there is a better way to achieve what I'm trying to do I love to hear that as well. Searching around, I found many people with this wish, but no solution, therefore I created this PR.