### PR TITLE
Update date-fns to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@sanity/uuid": "^3.0.1",
     "@tanem/react-nprogress": "^5.0.0",
     "copy-to-clipboard": "^3.3.1",
-    "date-fns": "^2.27.0",
+    "date-fns": "^3.6.0",
     "filesize": "^9.0.0",
     "groq": "^3.0.0",
     "is-hotkey": "^0.2.0",


### PR DESCRIPTION
[Fixes build issues](https://github.com/sanity-io/sanity/issues/6477#issuecomment-2227285117), `date-fns` 2 / 3 both have same API, so there is no further needed in the usage.