### PR TITLE
Allow users to specify maximum upload size

### DIFF
--- a/src/components/Tool/index.tsx
+++ b/src/components/Tool/index.tsx
@@ -1,12 +1,17 @@
 import {Flex} from '@sanity/ui'
-import React from 'react'
+import React, {ComponentProps} from 'react'
 import Browser from '../Browser'
+import {ToolOptionsProvider} from '../../contexts/ToolOptionsContext'
+import {Tool as SanityTool} from 'sanity'
+import {MediaToolOptions} from '@types'
 
-const Tool = () => {
+const Tool = ({tool: {options}}: ComponentProps<SanityTool<MediaToolOptions>['component']>) => {
   return (
-    <Flex direction="column" height="fill" flex={1}>
-      <Browser />
-    </Flex>
+    <ToolOptionsProvider options={options}>
+      <Flex direction="column" height="fill" flex={1}>
+        <Browser />
+      </Flex>
+    </ToolOptionsProvider>
   )
 }
 

--- a/src/contexts/ToolOptionsContext.tsx
+++ b/src/contexts/ToolOptionsContext.tsx
@@ -1,0 +1,34 @@
+import {MediaToolOptions} from '@types'
+import React, {PropsWithChildren, createContext, useContext, useMemo} from 'react'
+import {DropzoneOptions} from 'react-dropzone'
+
+type ContextProps = {
+  dropzone: Pick<DropzoneOptions, 'maxSize'>
+}
+
+const ToolOptionsContext = createContext<ContextProps | null>(null)
+
+type Props = {
+  options?: MediaToolOptions
+}
+
+export const ToolOptionsProvider = ({options, children}: PropsWithChildren<Props>) => {
+  const value = useMemo<ContextProps>(
+    () => ({dropzone: {maxSize: options?.maximumUploadSize}}),
+    [options?.maximumUploadSize]
+  )
+
+  return <ToolOptionsContext.Provider value={value}>{children}</ToolOptionsContext.Provider>
+}
+
+export const useToolOptions = () => {
+  const context = useContext(ToolOptionsContext)
+
+  if (!context) {
+    throw new Error('useToolOptions must be used within an ToolOptionsProvider')
+  }
+
+  return context
+}
+
+export default ToolOptionsContext

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
-import {definePlugin, Tool as SanityTool} from 'sanity'
+import {definePlugin} from 'sanity'
 import {ImageIcon} from '@sanity/icons'
 import type {AssetSource} from 'sanity'
 import FormBuilderTool from './components/FormBuilderTool'
 import Tool from './components/Tool'
 import mediaTag from './schemas/tag'
+import {MediaToolOptions} from '@types'
 
 const plugin = {
   icon: ImageIcon,
@@ -16,12 +17,7 @@ export const mediaAssetSource: AssetSource = {
   component: FormBuilderTool
 }
 
-const tool = {
-  ...plugin,
-  component: Tool
-} as SanityTool
-
-export const media = definePlugin({
+export const media = definePlugin<MediaToolOptions | void>(options => ({
   name: 'media',
   form: {
     file: {
@@ -39,6 +35,13 @@ export const media = definePlugin({
     types: [mediaTag]
   },
   tools: prev => {
-    return [...prev, tool]
+    return [
+      ...prev,
+      {
+        ...plugin,
+        options,
+        component: Tool
+      }
+    ]
   }
-})
+}))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,10 @@ import * as z from 'zod'
 import {assetFormSchema, tagFormSchema, tagOptionSchema} from '../formSchema'
 import {RootReducerState} from '../modules/types'
 
+export type MediaToolOptions = {
+  maximumUploadSize?: number
+}
+
 type CustomFields = {
   altText?: string
   description?: string


### PR DESCRIPTION
Addresses https://github.com/sanity-io/sanity-plugin-media/issues/203

Prior to this PR, the media plugin had no customisation options. In particular, there was no way to specify maximum upload size, even though the underlying dropzone component has support for it. This PR is focused around customising the dropzone with [`maxSize`](https://react-dropzone.js.org/#src) and [`onDropRejected`](https://react-dropzone.js.org/#src) properties. This PR also introduces `MediaToolOptions` as a customer-facing API for customising the plugin.

Tool options are stored in `ToolOptionsContext`, which is exposed to the whole application through `useToolOptions` hook.

If any of the uploaded files is rejected with `file-too-large` error code, an error toast will be shown to the customer.
