### PR TITLE
feat: add __internalApplicationType to tool spec

### DIFF
--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -20,7 +20,9 @@ export const mediaAssetSource = {
 
 const tool = {
   ...plugin,
-  component: Tool
+  component: Tool,
+  // @ts-expect-error TS doesn't know about this internal field see https://github.com/sanity-io/sanity/pull/7980
+  __internalApplicationType: 'sanity/media'
 } satisfies SanityTool
 
 export const media = definePlugin<MediaToolOptions | void>(options => ({


### PR DESCRIPTION
Adds the __internalApplicationType property to the configuration of the tool as part of the CoreUI project. More information can be seen here – https://github.com/sanity-io/sanity/pull/7980 – we added this parameter to many of the common tools sanity provides.

TLDR; this helps us identify & group tools across studio manifests to be used for the CoreUI menus etc. We see it as a temporary measure of using a studio manifest (similar to create) and this will be replaced in the ✨ future ✨.