### PR TITLE
fix: fixed grid view only show 1 item bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.3](https://github.com/sanity-io/sanity-plugin-media/compare/v3.0.2...v3.0.3) (2025-04-30)
+
+### Bug Fixes
+
+- fix: forward refs in AssetGridVirtualized ListContainer/ItemContainer for react-virtuoso compatibility ([see details](https://github.com/sanity-io/sanity-plugin-media/commit/HEAD))
+
 ## [3.0.2](https://github.com/sanity-io/sanity-plugin-media/compare/v3.0.1...v3.0.2) (2025-03-19)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sanity-plugin-media",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sanity-plugin-media",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-plugin-media",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "This version of `sanity-plugin-media` is for Sanity Studio V3.",
   "keywords": [
     "sanity",

--- a/src/components/AssetGridVirtualized/index.tsx
+++ b/src/components/AssetGridVirtualized/index.tsx
@@ -1,5 +1,5 @@
 import type {CardAssetData, CardUploadData} from '../../types'
-import {memo} from 'react'
+import {memo, forwardRef} from 'react'
 import {VirtuosoGrid} from 'react-virtuoso'
 import {styled} from 'styled-components'
 import useTypedSelector from '../../hooks/useTypedSelector'
@@ -33,11 +33,11 @@ const StyledItemContainer = styled.div`
   width: ${CARD_WIDTH}px;
 `
 
-function ItemContainer(props: any) {
+const ItemContainer = forwardRef<HTMLDivElement, any>((props, ref) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we're doing this to avoid sc warnings about `context` passed as an attribute
   const {context, ...rest} = props
-  return <StyledItemContainer {...rest} />
-}
+  return <StyledItemContainer ref={ref} {...rest} />
+})
 
 const StyledListContainer = styled.div`
   display: grid;
@@ -46,11 +46,12 @@ const StyledListContainer = styled.div`
   justify-content: center;
   margin: 0 auto;
 `
-function ListContainer(props: any) {
+
+const ListContainer = forwardRef<HTMLDivElement, any>((props, ref) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we're doing this to avoid sc warnings about `context` passed as an attribute
   const {context, ...rest} = props
-  return <StyledListContainer {...rest} />
-}
+  return <StyledListContainer ref={ref} {...rest} />
+})
 
 const AssetGridVirtualized = (props: Props) => {
   const {items, onLoadMore} = props


### PR DESCRIPTION
Added forwardRef to fix virtualized grid item and list container refs

fixed https://github.com/sanity-io/sanity-plugin-media/issues/251

![CleanShot 2025-04-30 at 11 42 47](https://github.com/user-attachments/assets/84216f9d-7ece-4ab7-9754-5a283cb76c9d)
