### PR TITLE
fix: update date-fns imports to v4 syntax

### DIFF
--- a/src/components/AssetMetadata/index.tsx
+++ b/src/components/AssetMetadata/index.tsx
@@ -1,7 +1,7 @@
 import {DownloadIcon} from '@sanity/icons'
 import {Box, Button, Flex, Inline, Stack, Text} from '@sanity/ui'
 import type {Asset, AssetItem} from '../../types'
-import format from 'date-fns/format'
+import { format } from 'date-fns'
 import filesize from 'filesize'
 import {type ReactNode} from 'react'
 import getAssetResolution from '../../utils/getAssetResolution'

--- a/src/components/FormSubmitButton/index.tsx
+++ b/src/components/FormSubmitButton/index.tsx
@@ -1,5 +1,5 @@
 import {Box, Button, Text, Tooltip} from '@sanity/ui'
-import format from 'date-fns/format'
+import { format } from 'date-fns'
 import {type ReactNode} from 'react'
 
 type Props = {

--- a/src/components/TableRowAsset/index.tsx
+++ b/src/components/TableRowAsset/index.tsx
@@ -11,7 +11,7 @@ import {
   Tooltip,
   useMediaIndex
 } from '@sanity/ui'
-import formatRelative from 'date-fns/formatRelative'
+import { formatRelative } from 'date-fns'
 import filesize from 'filesize'
 import {
   memo,


### PR DESCRIPTION
## Description

This PR fixes the `date-fns` import compatibility issue that occurs when using `date-fns` v4.0.0+ with the `sanity-plugin-media` package.

## Problem

The plugin was using the old `date-fns` v3 import syntax:
- `import format from 'date-fns/format'`
- `import formatRelative from 'date-fns/formatRelative'`

But the package.json specified `date-fns: ^4.0.0`, which uses a different import syntax. This caused the error:
```
TypeError: formatRelative__default.default is not a function
```

## Solution

Updated all `date-fns` imports to use the v4 syntax:
- `import { format } from 'date-fns'`
- `import { formatRelative } from 'date-fns'`

This change maintains backward compatibility with `date-fns` v3 while fixing the v4 compatibility issue.

## Files Changed

- `src/components/AssetMetadata/index.tsx`
- `src/components/FormSubmitButton/index.tsx`
- `src/components/TableRowAsset/index.tsx`

## Testing

- TypeScript compilation passes without errors
- The import syntax is compatible with both date-fns v3 and v4
- No breaking changes to the public API

## Related Issue

Closes #262

## References

- [date-fns v4 migration guide](https://date-fns.org/v4.0.0/docs/formatRelative)
- [Issue #262](https://github.com/sanity-io/sanity-plugin-media/issues/262)