### PR TITLE
feat: allow 'directUploads' option on the tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ export default defineConfig({
       },
       maximumUploadSize: 10000000
       // number - maximum file size (in bytes) that can be uploaded through the plugin interface
+      directUploads: true
+      // boolean - enable / disable direct uploads through the plugin interface (default true)
     })
   ],
 })

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -5,6 +5,7 @@ import pluralize from 'pluralize'
 import {useAssetSourceActions} from '../../contexts/AssetSourceDispatchContext'
 import {useDropzoneActions} from '../../contexts/DropzoneDispatchContext'
 import useTypedSelector from '../../hooks/useTypedSelector'
+import {useToolOptions} from '../../contexts/ToolOptionsContext'
 
 type Props = {
   onClose?: () => void
@@ -19,6 +20,8 @@ const Header = (props: Props) => {
   // Redux
   const assetTypes = useTypedSelector(state => state.assets.assetTypes)
   const selectedDocument = useTypedSelector(state => state.selected.document)
+
+  const {directUploads} = useToolOptions()
 
   // Row: Current document / close button
   return (
@@ -46,14 +49,15 @@ const Header = (props: Props) => {
 
         <Flex marginX={2}>
           {/* Upload */}
-          <Button
-            fontSize={1}
-            icon={UploadIcon}
-            mode="bleed"
-            onClick={open}
-            text={`Upload ${assetTypes.length === 1 ? pluralize(assetTypes[0]) : 'assets'}`}
-            tone="primary"
-          />
+          {directUploads && (
+            <Button
+              fontSize={1}
+              icon={UploadIcon}
+              mode="bleed"
+              onClick={open}
+              text={`Upload ${assetTypes.length === 1 ? pluralize(assetTypes[0]) : 'assets'}`}
+            />
+          )}
 
           {/* Close */}
           {onClose && (

--- a/src/components/UploadDropzone/index.tsx
+++ b/src/components/UploadDropzone/index.tsx
@@ -64,7 +64,8 @@ const UploadDropzone = (props: Props) => {
   const {children} = props
 
   const {
-    dropzone: {maxSize}
+    dropzone: {maxSize},
+    directUploads
   } = useToolOptions()
 
   const {onSelect} = useAssetSourceActions()
@@ -143,7 +144,8 @@ const UploadDropzone = (props: Props) => {
     noDrag: !!onSelect,
     onDrop: handleDrop,
     maxSize,
-    onDropRejected: handleDropRejected
+    onDropRejected: handleDropRejected,
+    disabled: !directUploads
   })
 
   return (

--- a/src/contexts/ToolOptionsContext.tsx
+++ b/src/contexts/ToolOptionsContext.tsx
@@ -5,6 +5,7 @@ import type {DropzoneOptions} from 'react-dropzone'
 type ContextProps = {
   dropzone: Pick<DropzoneOptions, 'maxSize'>
   creditLine: MediaToolOptions['creditLine']
+  directUploads: MediaToolOptions['directUploads']
 }
 
 const ToolOptionsContext = createContext<ContextProps | null>(null)
@@ -28,12 +29,14 @@ export const ToolOptionsProvider = ({options, children}: PropsWithChildren<Props
       creditLine: {
         enabled: options?.creditLine?.enabled || false,
         excludeSources: creditLineExcludeSources
-      }
+      },
+      directUploads: options?.directUploads ?? true
     }
   }, [
     options?.creditLine?.enabled,
     options?.creditLine?.excludeSources,
-    options?.maximumUploadSize
+    options?.maximumUploadSize,
+    options?.directUploads
   ])
 
   return <ToolOptionsContext.Provider value={value}>{children}</ToolOptionsContext.Provider>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,7 @@ export type MediaToolOptions = {
     enabled: boolean
     excludeSources?: string | string[]
   }
+  directUploads?: boolean
 }
 
 type CustomFields = {


### PR DESCRIPTION
### Description
Creates the ability to disable uploads through the tool.
Aligned with the form api.

Closes #264 

### Testing
Tested in a local studio
