### PR TITLE
feat: create ability to define a custom compoenent to present details

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,14 @@ export default defineConfig({
 })
 ```
 
+
 ### Plugin Config
 
 ```ts
 // sanity.config.ts
+import {media} from 'sanity-plugin-media'
+import {CustomDetails} from './MyCustomDetails'
+
 export default defineConfig({
   //...
   plugins: [
@@ -113,9 +117,34 @@ export default defineConfig({
       },
       maximumUploadSize: 10000000
       // number - maximum file size (in bytes) that can be uploaded through the plugin interface
+      components: {
+        details: CustomDetails
+        // Custom component for asset details (see below)
+      }
+      // Custom components to override default UI (see below)
     })
   ],
 })
+```
+
+#### Custom Asset Details Component
+
+Custom React component for the asset details form via the plugin config. This allows you to override or extend the default asset details UI.
+
+Your component will receive all form props and a `renderDefaultDetails(props)` function for fallback or composition.
+
+```tsx
+// Example custom details component
+export function CustomDetails(props) {
+  // You can render the default details, or add your own fields
+  return (
+    <>
+      <h3>Custom header</h3>
+      {/* Change the UI as you see fit */}
+      {props.renderDefaultDetails(props)}
+    </>
+  )
+}
 ```
 
 ## Known issues

--- a/src/components/DialogAssetEdit/Details.tsx
+++ b/src/components/DialogAssetEdit/Details.tsx
@@ -1,0 +1,101 @@
+import {Stack} from '@sanity/ui'
+import type {Asset, AssetFormData, TagSelectOption} from '../../types'
+import {type Control, type FieldErrors, type UseFormRegister} from 'react-hook-form'
+
+import FormFieldInputTags from '../FormFieldInputTags'
+import FormFieldInputText from '../FormFieldInputText'
+import FormFieldInputTextarea from '../FormFieldInputTextarea'
+
+export type DetailsProps = {
+  formUpdating: boolean
+  handleCreateTag: (title: string) => void
+  control: Control<AssetFormData>
+  errors: FieldErrors<AssetFormData>
+  register: UseFormRegister<AssetFormData>
+  allTagOptions: TagSelectOption[]
+  assetTagOptions: TagSelectOption[] | null
+  currentAsset: Asset
+  creditLine?: {
+    enabled: boolean
+    excludeSources?: string | string[] | undefined
+  }
+}
+
+export default function Details({
+  formUpdating,
+  handleCreateTag,
+  control,
+  errors,
+  register,
+  allTagOptions,
+  assetTagOptions,
+  currentAsset,
+  creditLine
+}: DetailsProps) {
+  return (
+    <Stack space={3}>
+      {/* Tags */}
+      <FormFieldInputTags
+        control={control}
+        disabled={formUpdating}
+        error={errors?.opt?.media?.tags?.message}
+        label="Tags"
+        name="opt.media.tags"
+        onCreateTag={handleCreateTag}
+        options={allTagOptions}
+        placeholder="Select or create..."
+        value={assetTagOptions}
+      />
+      {/* Filename */}
+      <FormFieldInputText
+        {...register('originalFilename')}
+        disabled={formUpdating}
+        error={errors?.originalFilename?.message}
+        label="Filename"
+        name="originalFilename"
+        value={currentAsset?.originalFilename}
+      />
+      {/* Title */}
+      <FormFieldInputText
+        {...register('title')}
+        disabled={formUpdating}
+        error={errors?.title?.message}
+        label="Title"
+        name="title"
+        value={currentAsset?.title}
+      />
+      {/* Alt text */}
+      <FormFieldInputText
+        {...register('altText')}
+        disabled={formUpdating}
+        error={errors?.altText?.message}
+        label="Alt Text"
+        name="altText"
+        value={currentAsset?.altText}
+      />
+      {/* Description */}
+      <FormFieldInputTextarea
+        {...register('description')}
+        disabled={formUpdating}
+        error={errors?.description?.message}
+        label="Description"
+        name="description"
+        rows={5}
+        value={currentAsset?.description}
+      />
+      {/* CreditLine */}
+      {creditLine?.enabled && (
+        <FormFieldInputText
+          {...register('creditLine')}
+          error={errors?.creditLine?.message}
+          label="Credit"
+          name="creditLine"
+          value={currentAsset?.creditLine}
+          disabled={
+            formUpdating || creditLine?.excludeSources?.includes(currentAsset?.source?.name)
+          }
+        />
+      )}
+    </Stack>
+  )
+}

--- a/src/components/DialogAssetEdit/index.tsx
+++ b/src/components/DialogAssetEdit/index.tsx
@@ -1,6 +1,6 @@
 import {zodResolver} from '@hookform/resolvers/zod'
 import type {MutationEvent} from '@sanity/client'
-import {Box, Button, Card, Flex, Stack, Tab, TabList, TabPanel, Text} from '@sanity/ui'
+import {Box, Button, Card, Flex, Tab, TabList, TabPanel, Text} from '@sanity/ui'
 import type {Asset, AssetFormData, DialogAssetEditProps, TagSelectOption} from '../../types'
 import groq from 'groq'
 import {type ReactNode, useCallback, useEffect, useRef, useState} from 'react'
@@ -22,12 +22,14 @@ import AssetMetadata from '../AssetMetadata'
 import Dialog from '../Dialog'
 import DocumentList from '../DocumentList'
 import FileAssetPreview from '../FileAssetPreview'
-import FormFieldInputTags from '../FormFieldInputTags'
-import FormFieldInputText from '../FormFieldInputText'
-import FormFieldInputTextarea from '../FormFieldInputTextarea'
 import FormSubmitButton from '../FormSubmitButton'
 import Image from '../Image'
 import {useToolOptions} from '../../contexts/ToolOptionsContext'
+import Details, {type DetailsProps} from './Details'
+
+function renderDefaultDetails(props: DetailsProps) {
+  return <Details {...props} />
+}
 
 type Props = {
   children: ReactNode
@@ -61,7 +63,7 @@ const DialogAssetEdit = (props: Props) => {
   const assetTagOptions = useTypedSelector(selectTagSelectOptions(currentAsset))
 
   // Check if credit line options are configured
-  const {creditLine} = useToolOptions()
+  const {creditLine, components: {details: CustomDetails} = {}} = useToolOptions()
 
   const generateDefaultValues = useCallback(
     (asset?: Asset): AssetFormData => {
@@ -239,6 +241,19 @@ const DialogAssetEdit = (props: Props) => {
     return null
   }
 
+  const detailsProps = {
+    control,
+    errors,
+    formUpdating,
+    register,
+    setValue,
+    assetTagOptions,
+    allTagOptions,
+    handleCreateTag,
+    currentAsset,
+    creditLine
+  }
+
   return (
     <Dialog
       animate
@@ -304,71 +319,14 @@ const DialogAssetEdit = (props: Props) => {
                       hidden={tabSection !== 'details'}
                       id="details-panel"
                     >
-                      <Stack space={3}>
-                        {/* Tags */}
-                        <FormFieldInputTags
-                          control={control}
-                          disabled={formUpdating}
-                          error={errors?.opt?.media?.tags?.message}
-                          label="Tags"
-                          name="opt.media.tags"
-                          onCreateTag={handleCreateTag}
-                          options={allTagOptions}
-                          placeholder="Select or create..."
-                          value={assetTagOptions}
+                      {CustomDetails ? (
+                        <CustomDetails
+                          {...detailsProps}
+                          renderDefaultDetails={renderDefaultDetails}
                         />
-                        {/* Filename */}
-                        <FormFieldInputText
-                          {...register('originalFilename')}
-                          disabled={formUpdating}
-                          error={errors?.originalFilename?.message}
-                          label="Filename"
-                          name="originalFilename"
-                          value={currentAsset?.originalFilename}
-                        />
-                        {/* Title */}
-                        <FormFieldInputText
-                          {...register('title')}
-                          disabled={formUpdating}
-                          error={errors?.title?.message}
-                          label="Title"
-                          name="title"
-                          value={currentAsset?.title}
-                        />
-                        {/* Alt text */}
-                        <FormFieldInputText
-                          {...register('altText')}
-                          disabled={formUpdating}
-                          error={errors?.altText?.message}
-                          label="Alt Text"
-                          name="altText"
-                          value={currentAsset?.altText}
-                        />
-                        {/* Description */}
-                        <FormFieldInputTextarea
-                          {...register('description')}
-                          disabled={formUpdating}
-                          error={errors?.description?.message}
-                          label="Description"
-                          name="description"
-                          rows={5}
-                          value={currentAsset?.description}
-                        />
-                        {/* CreditLine */}
-                        {creditLine?.enabled && (
-                          <FormFieldInputText
-                            {...register('creditLine')}
-                            error={errors?.creditLine?.message}
-                            label="Credit"
-                            name="creditLine"
-                            value={currentAsset?.creditLine}
-                            disabled={
-                              formUpdating ||
-                              creditLine?.excludeSources?.includes(currentAsset?.source?.name)
-                            }
-                          />
-                        )}
-                      </Stack>
+                      ) : (
+                        <Details {...detailsProps} />
+                      )}
                     </TabPanel>
 
                     {/* Panel: References */}

--- a/src/contexts/ToolOptionsContext.tsx
+++ b/src/contexts/ToolOptionsContext.tsx
@@ -4,6 +4,7 @@ import type {DropzoneOptions} from 'react-dropzone'
 
 type ContextProps = {
   dropzone: Pick<DropzoneOptions, 'maxSize'>
+  components: MediaToolOptions['components']
   creditLine: MediaToolOptions['creditLine']
 }
 
@@ -25,6 +26,9 @@ export const ToolOptionsProvider = ({options, children}: PropsWithChildren<Props
 
     return {
       dropzone: {maxSize: options?.maximumUploadSize},
+      components: {
+        details: options?.components?.details
+      },
       creditLine: {
         enabled: options?.creditLine?.enabled || false,
         excludeSources: creditLineExcludeSources
@@ -32,6 +36,7 @@ export const ToolOptionsProvider = ({options, children}: PropsWithChildren<Props
     }
   }, [
     options?.creditLine?.enabled,
+    options?.components,
     options?.creditLine?.excludeSources,
     options?.maximumUploadSize
   ])

--- a/src/modules/assets/index.ts
+++ b/src/modules/assets/index.ts
@@ -254,7 +254,9 @@ const assetsSlice = createSlice({
               originalFilename,
               size,
               source {
-                name
+                name,
+                id,
+                url,
               },
               title,
               url

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,13 +5,20 @@ import type {
   SanityDocument,
   SanityImageAssetDocument
 } from '@sanity/client'
+import type {ComponentType, JSX} from 'react'
 import type {Epic} from 'redux-observable'
 import * as z from 'zod'
 import {assetFormSchema, tagFormSchema, tagOptionSchema} from '../formSchema'
 import type {RootReducerState} from '../modules/types'
+import type {DetailsProps} from '../components/DialogAssetEdit/Details'
 
 export type MediaToolOptions = {
   maximumUploadSize?: number
+  components?: {
+    details?: ComponentType<
+      DetailsProps & {renderDefaultDetails: (props: DetailsProps) => JSX.Element}
+    >
+  }
   creditLine: {
     enabled: boolean
     excludeSources?: string | string[]


### PR DESCRIPTION
### Description
This pull request enables the definition of a custom component to represent details in the edit dialog.
This allows us to build a better experience, for example, if you don't want a certain field to be editable for a specific user or (for example) want to display some extra details from a different source.

### Testing
Tested in a local studio
