### PR TITLE
feat: localized asset fields options

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,9 @@ export default defineConfig({
 })
 ```
 
-
 ### Plugin Config
 
-```ts
+````ts
 // sanity.config.ts
 import {media} from 'sanity-plugin-media'
 import {CustomDetails} from './MyCustomDetails'
@@ -124,10 +123,32 @@ export default defineConfig({
         // Custom component for asset details (see below)
       }
       // Custom components to override default UI (see below)
+      // Optional: Enable localization support (see https://www.sanity.io/docs/studio/localization#k4da239411955)
+      // locales: [
+      //   { id: 'en', title: 'English' },
+      //   { id: 'no', title: 'Norwegian' },
+      //   { id: 'fr', title: 'French' }
+      // ],
     })
   ],
 })
-```
+### Localization (Optional)
+
+You can enable localization support by passing a `locales` array to the plugin config, following the [Sanity recommended scheme](https://www.sanity.io/docs/studio/localization#k4da239411955):
+
+```js
+media({
+  locales: [
+    { id: 'en', title: 'English' },
+    { id: 'no', title: 'Norwegian' },
+    { id: 'fr', title: 'French' }
+  ]
+})
+````
+
+If omitted, localization features will be disabled and the plugin will work as usual.
+
+````
 
 #### Custom Asset Details Component
 
@@ -147,7 +168,7 @@ export function CustomDetails(props) {
     </>
   )
 }
-```
+````
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ export default defineConfig({
 
 ### Plugin Config
 
-````ts
+```ts
 // sanity.config.ts
 import {media} from 'sanity-plugin-media'
 import {CustomDetails} from './MyCustomDetails'
@@ -110,7 +110,7 @@ export default defineConfig({
         enabled: true,
         // boolean - enables an optional "Credit Line" field in the plugin.
         // Used to store credits e.g. photographer, licence information
-        excludeSources: ['unsplash'],
+        excludeSources: ['unsplash']
         // string | string[] - when used with 3rd party asset sources, you may
         // wish to prevent users overwriting the creditLine based on the `source.name`
       },
@@ -121,34 +121,45 @@ export default defineConfig({
       components: {
         details: CustomDetails
         // Custom component for asset details (see below)
-      }
+      },
       // Custom components to override default UI (see below)
-      // Optional: Enable localization support (see https://www.sanity.io/docs/studio/localization#k4da239411955)
-      // locales: [
-      //   { id: 'en', title: 'English' },
-      //   { id: 'no', title: 'Norwegian' },
-      //   { id: 'fr', title: 'French' }
-      // ],
+      locales: [
+        // { id: string, title: string, ...extra }[] - enable localization for asset fields. Each object must have a unique id and a human-readable title.
+        // You may include extra keys (e.g. isDefault) for compatibility with Sanity's recommended pattern; only id and title are used by the plugin, all other keys are ignored.
+        // When set, all localizable fields (title, altText, description, creditLine) will be shown in tabs by language.
+        {id: 'en', title: 'English', isDefault: true},
+        {id: 'it', title: 'Italian'},
+        {id: 'es', title: 'Spanish'},
+        {id: 'fr', title: 'French'},
+        {id: 'de', title: 'German'},
+        {id: 'pt', title: 'Portuguese'},
+        {id: 'ja', title: 'Japanese'},
+        {id: 'zh', title: 'Chinese'},
+        {id: 'ru', title: 'Russian'},
+        {id: 'ar', title: 'Arabic'}
+      ]
     })
-  ],
+  ]
 })
+```
+
 ### Localization (Optional)
 
 You can enable localization support by passing a `locales` array to the plugin config, following the [Sanity recommended scheme](https://www.sanity.io/docs/studio/localization#k4da239411955):
 
-```js
-media({
-  locales: [
-    { id: 'en', title: 'English' },
-    { id: 'no', title: 'Norwegian' },
-    { id: 'fr', title: 'French' }
-  ]
-})
-````
-
 If omitted, localization features will be disabled and the plugin will work as usual.
 
-````
+**Fallback for missing translations:**
+The plugin does not apply any automatic fallback for missing translations. You can decide how to handle this in your queries or frontend logic. For example, to show the default language if a translation is missing, you can use GROQ's `coalesce()`:
+
+```
+coalesce(altText.it, altText.en)
+```
+
+**UI note:**
+When `locales` are provided, all localized fields (title, altText, description, creditLine) are grouped by language in tabs. Each tab shows all fields for a single language, making it easy to edit translations for many languages in a compact interface.
+
+This will return the Italian value if present, otherwise English, otherwise French, etc. Adjust the order as needed for your project.
 
 #### Custom Asset Details Component
 
@@ -168,7 +179,7 @@ export function CustomDetails(props) {
     </>
   )
 }
-````
+```
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ npx sanity@latest migration run scripts/migrate-to-localized-fields.ts \
 
 The script targets `sanity.imageAsset` and `sanity.fileAsset` documents and converts any plain string value in `title`, `altText`, `description`, and `creditLine` to `{[DEFAULT_LOCALE_ID]: value}`. Fields that are already in object format are left untouched.
 
-> **Without migration:** Opening and saving an asset in the plugin will automatically migrate its fields on save. Running the script ensures all assets are consistent before users start editing.
+> **Without migration:** Legacy string fields can also be migrated when an asset is edited and saved in the plugin. Running the script is still recommended to migrate all existing assets consistently before users start editing.
 
 #### Removing locales
 

--- a/README.md
+++ b/README.md
@@ -125,9 +125,8 @@ export default defineConfig({
       // Custom components to override default UI (see below)
       locales: [
         // { id: string, title: string, ...extra }[] - enable localization for asset fields. Each object must have a unique id and a human-readable title.
-        // You may include extra keys (e.g. isDefault) for compatibility with Sanity's recommended pattern; only id and title are used by the plugin, all other keys are ignored.
         // When set, all localizable fields (title, altText, description, creditLine) will be shown in tabs by language.
-        {id: 'en', title: 'English', isDefault: true},
+        {id: 'en', title: 'English'},
         {id: 'it', title: 'Italian'},
         {id: 'es', title: 'Spanish'},
         {id: 'fr', title: 'French'},

--- a/README.md
+++ b/README.md
@@ -161,6 +161,27 @@ When `locales` are provided, all localized fields (title, altText, description, 
 
 This will return the Italian value if present, otherwise English, otherwise French, etc. Adjust the order as needed for your project.
 
+#### Migrating existing assets to localized format
+
+If you enable `locales` on a project that already has assets with plain string fields (e.g. `title: "My photo"`), you should run the provided migration script to convert those fields to the localized object format (e.g. `title: {en: "My photo"}`).
+
+**1. Edit the script** — open `scripts/migrate-to-localized-fields.ts` and set `DEFAULT_LOCALE_ID` to the locale id that your existing values should be mapped to.
+
+**2. Run the migration:**
+
+```sh
+npx sanity@latest migration run scripts/migrate-to-localized-fields.ts \
+  --project <projectId> --dataset <dataset>
+```
+
+The script targets `sanity.imageAsset` and `sanity.fileAsset` documents and converts any plain string value in `title`, `altText`, `description`, and `creditLine` to `{[DEFAULT_LOCALE_ID]: value}`. Fields that are already in object format are left untouched.
+
+> **Without migration:** Opening and saving an asset in the plugin will automatically migrate its fields on save. Running the script ensures all assets are consistent before users start editing.
+
+#### Removing locales
+
+If you remove the `locales` option after assets have been saved in localized format, the plugin will show a warning in the asset edit dialog offering a **"Cleanup localized fields"** action. Clicking it removes locale keys that are no longer configured and, if no locales remain, flattens the fields back to plain strings.
+
 #### Custom Asset Details Component
 
 Custom React component for the asset details form via the plugin config. This allows you to override or extend the default asset details UI.

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -3,22 +3,7 @@ import {media} from './src'
 
 export default defineConfig({
   name: 'sanity-plugin-media',
-  projectId: 'z13xc6hl',
-  dataset: 'production',
-  // projectId: 'ppsg7ml5',
-  // dataset: 'test',
-  plugins: [
-    media({
-      locales: [
-        {
-          title: 'Italian',
-          id: 'it'
-        },
-        {
-          title: 'English',
-          id: 'en'
-        }
-      ]
-    })
-  ]
+  projectId: 'ppsg7ml5',
+  dataset: 'test',
+  plugins: [media()]
 })

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -3,7 +3,22 @@ import {media} from './src'
 
 export default defineConfig({
   name: 'sanity-plugin-media',
-  projectId: 'ppsg7ml5',
-  dataset: 'test',
-  plugins: [media()]
+  projectId: 'z13xc6hl',
+  dataset: 'production',
+  // projectId: 'ppsg7ml5',
+  // dataset: 'test',
+  plugins: [
+    media({
+      locales: [
+        {
+          title: 'Italian',
+          id: 'it'
+        },
+        {
+          title: 'English',
+          id: 'en'
+        }
+      ]
+    })
+  ]
 })

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,16 +1,9 @@
-import { defineConfig } from 'sanity'
-import { media } from './src'
+import {defineConfig} from 'sanity'
+import {media} from './src'
 
 export default defineConfig({
   name: 'sanity-plugin-media',
-  projectId: 'xrn5spf3',
-  dataset: 'production',
-  plugins: [
-    media({
-      locales: [
-        {id: 'en', title: 'English'},
-        {id: 'it', title: 'Italiano'}
-      ]
-    })
-  ]
+  projectId: 'ppsg7ml5',
+  dataset: 'test',
+  plugins: [media()]
 })

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,9 +1,16 @@
-import {defineConfig} from 'sanity'
-import {media} from './src'
+import { defineConfig } from 'sanity'
+import { media } from './src'
 
 export default defineConfig({
   name: 'sanity-plugin-media',
-  projectId: 'ppsg7ml5',
-  dataset: 'test',
-  plugins: [media()]
+  projectId: 'xrn5spf3',
+  dataset: 'production',
+  plugins: [
+    media({
+      locales: [
+        {id: 'en', title: 'English'},
+        {id: 'it', title: 'Italiano'}
+      ]
+    })
+  ]
 })

--- a/scripts/migrate-to-localized-fields.ts
+++ b/scripts/migrate-to-localized-fields.ts
@@ -15,18 +15,24 @@ import {defineMigration, patch} from 'sanity/migrate'
 
 const DEFAULT_LOCALE_ID = 'en' // Change to your default locale id
 
-const LOCALIZED_FIELDS = ['title', 'altText', 'description', 'creditLine'] as const
-const ASSET_TYPES = ['sanity.imageAsset', 'sanity.fileAsset'] as const
+// Fields shared between image and file assets
+const COMMON_LOCALIZED_FIELDS = ['title', 'altText', 'description'] as const
+// creditLine only exists on sanity.imageAsset
+const IMAGE_ONLY_LOCALIZED_FIELDS = ['creditLine'] as const
 
 export default defineMigration({
   title: 'Convert flat asset fields to localized object format',
-  filter: `_type in ${JSON.stringify(ASSET_TYPES)}`,
+  filter: `_type in ["sanity.imageAsset", "sanity.fileAsset"]`,
 
   migrate: {
     document(doc) {
       const ops = []
+      const fields =
+        doc._type === 'sanity.imageAsset'
+          ? ([...COMMON_LOCALIZED_FIELDS, ...IMAGE_ONLY_LOCALIZED_FIELDS] as const)
+          : COMMON_LOCALIZED_FIELDS
 
-      for (const field of LOCALIZED_FIELDS) {
+      for (const field of fields) {
         const value = (doc as Record<string, unknown>)[field]
 
         if (typeof value === 'string') {

--- a/scripts/migrate-to-localized-fields.ts
+++ b/scripts/migrate-to-localized-fields.ts
@@ -1,0 +1,44 @@
+/**
+ * Migration: Convert flat string asset fields to localized object format.
+ *
+ * Run with:
+ *   npx sanity@latest migration run scripts/migrate-to-localized-fields.ts \
+ *     --project <projectId> --dataset <dataset>
+ *
+ * See: https://www.sanity.io/docs/content-lake/content-migration-cheatsheet
+ *
+ * Before running, set DEFAULT_LOCALE_ID to the locale id that existing
+ * string values should be mapped to.
+ */
+
+import {defineMigration, patch} from 'sanity/migrate'
+
+const DEFAULT_LOCALE_ID = 'en' // Change to your default locale id
+
+const LOCALIZED_FIELDS = ['title', 'altText', 'description', 'creditLine'] as const
+const ASSET_TYPES = ['sanity.imageAsset', 'sanity.fileAsset'] as const
+
+export default defineMigration({
+  title: 'Convert flat asset fields to localized object format',
+  filter: `_type in ${JSON.stringify(ASSET_TYPES)}`,
+
+  migrate: {
+    document(doc) {
+      const ops = []
+
+      for (const field of LOCALIZED_FIELDS) {
+        const value = (doc as Record<string, unknown>)[field]
+
+        if (typeof value === 'string') {
+          // Convert string → {[defaultLocale]: string}
+          ops.push(patch(doc._id, [{set: {[field]: {[DEFAULT_LOCALE_ID]: value}}}]))
+        } else if (value === null || value === undefined) {
+          // Leave missing fields alone
+        }
+        // Already an object — already migrated, skip
+      }
+
+      return ops
+    }
+  }
+})

--- a/src/components/DialogAssetEdit/Details.tsx
+++ b/src/components/DialogAssetEdit/Details.tsx
@@ -19,6 +19,7 @@ export type DetailsProps = {
     enabled: boolean
     excludeSources?: string | string[] | undefined
   }
+  locales?: {id: string; title: string}[]
 }
 
 export default function Details({
@@ -30,8 +31,10 @@ export default function Details({
   allTagOptions,
   assetTagOptions,
   currentAsset,
-  creditLine
+  creditLine,
+  locales
 }: DetailsProps) {
+  const hasLocales = locales && locales.length > 0
   return (
     <Stack space={3}>
       {/* Tags */}
@@ -56,46 +59,104 @@ export default function Details({
         value={currentAsset?.originalFilename}
       />
       {/* Title */}
-      <FormFieldInputText
-        {...register('title')}
-        disabled={formUpdating}
-        error={errors?.title?.message}
-        label="Title"
-        name="title"
-        value={currentAsset?.title}
-      />
-      {/* Alt text */}
-      <FormFieldInputText
-        {...register('altText')}
-        disabled={formUpdating}
-        error={errors?.altText?.message}
-        label="Alt Text"
-        name="altText"
-        value={currentAsset?.altText}
-      />
-      {/* Description */}
-      <FormFieldInputTextarea
-        {...register('description')}
-        disabled={formUpdating}
-        error={errors?.description?.message}
-        label="Description"
-        name="description"
-        rows={5}
-        value={currentAsset?.description}
-      />
-      {/* CreditLine */}
-      {creditLine?.enabled && (
+      {hasLocales ? (
+        locales.map(locale => (
+          <FormFieldInputText
+            key={locale.id}
+            {...register(`title.${locale.id}` as const)}
+            disabled={formUpdating}
+            error={errors?.title?.[locale.id]?.message}
+            label={`Title (${locale.title})`}
+            name={`title.${locale.id}`}
+            value={currentAsset?.title?.[locale.id]}
+          />
+        ))
+      ) : (
         <FormFieldInputText
-          {...register('creditLine')}
-          error={errors?.creditLine?.message}
-          label="Credit"
-          name="creditLine"
-          value={currentAsset?.creditLine}
-          disabled={
-            formUpdating || creditLine?.excludeSources?.includes(currentAsset?.source?.name)
-          }
+          {...register('title')}
+          disabled={formUpdating}
+          error={errors?.title?.message}
+          label="Title"
+          name="title"
+          value={currentAsset?.title}
         />
       )}
+      {/* Alt text */}
+      {hasLocales ? (
+        locales.map(locale => (
+          <FormFieldInputText
+            key={locale.id}
+            {...register(`altText.${locale.id}` as const)}
+            disabled={formUpdating}
+            error={errors?.altText?.[locale.id]?.message}
+            label={`Alt Text (${locale.title})`}
+            name={`altText.${locale.id}`}
+            value={currentAsset?.altText?.[locale.id]}
+          />
+        ))
+      ) : (
+        <FormFieldInputText
+          {...register('altText')}
+          disabled={formUpdating}
+          error={errors?.altText?.message}
+          label="Alt Text"
+          name="altText"
+          value={currentAsset?.altText}
+        />
+      )}
+      {/* Description */}
+      {hasLocales ? (
+        locales.map(locale => (
+          <FormFieldInputTextarea
+            key={locale.id}
+            {...register(`description.${locale.id}` as const)}
+            disabled={formUpdating}
+            error={errors?.description?.[locale.id]?.message}
+            label={`Description (${locale.title})`}
+            name={`description.${locale.id}`}
+            rows={5}
+            value={currentAsset?.description?.[locale.id]}
+          />
+        ))
+      ) : (
+        <FormFieldInputTextarea
+          {...register('description')}
+          disabled={formUpdating}
+          error={errors?.description?.message}
+          label="Description"
+          name="description"
+          rows={5}
+          value={currentAsset?.description}
+        />
+      )}
+      {/* CreditLine */}
+      {creditLine?.enabled &&
+        (hasLocales ? (
+          locales.map(locale => (
+            <FormFieldInputText
+              key={locale.id}
+              {...register(`creditLine.${locale.id}` as const)}
+              error={errors?.creditLine?.[locale.id]?.message}
+              label={`Credit (${locale.title})`}
+              name={`creditLine.${locale.id}`}
+              value={currentAsset?.creditLine?.[locale.id]}
+              disabled={
+                formUpdating || creditLine?.excludeSources?.includes(currentAsset?.source?.name)
+              }
+            />
+          ))
+        ) : (
+          <FormFieldInputText
+            {...register('creditLine')}
+            error={errors?.creditLine?.message}
+            label="Credit"
+            name="creditLine"
+            value={currentAsset?.creditLine}
+            disabled={
+              formUpdating || creditLine?.excludeSources?.includes(currentAsset?.source?.name)
+            }
+          />
+        ))}
     </Stack>
   )
 }

--- a/src/components/DialogAssetEdit/Details.tsx
+++ b/src/components/DialogAssetEdit/Details.tsx
@@ -1,4 +1,5 @@
-import {Stack} from '@sanity/ui'
+import {Card, Stack, Tab, TabList, TabPanel} from '@sanity/ui'
+import {useState} from 'react'
 import type {Asset, AssetFormData, TagSelectOption} from '../../types'
 import {type Control, type FieldErrors, type UseFormRegister} from 'react-hook-form'
 
@@ -35,6 +36,7 @@ export default function Details({
   locales
 }: DetailsProps) {
   const hasLocales = locales && locales.length > 0
+  const [activeLocaleTab, setActiveLocaleTab] = useState(0)
   return (
     <Stack space={3}>
       {/* Tags */}
@@ -58,105 +60,114 @@ export default function Details({
         name="originalFilename"
         value={currentAsset?.originalFilename}
       />
-      {/* Title */}
+      {/* Localized fields grouped by language */}
       {hasLocales ? (
-        locales.map(locale => (
-          <FormFieldInputText
-            key={locale.id}
-            {...register(`title.${locale.id}` as const)}
-            disabled={formUpdating}
-            error={errors?.title?.[locale.id]?.message}
-            label={`Title (${locale.title})`}
-            name={`title.${locale.id}`}
-            value={currentAsset?.title?.[locale.id]}
-          />
-        ))
+        <Card marginTop={2} shadow={1} padding={3} radius={1}>
+          <Stack space={2}>
+            <TabList space={2}>
+              {locales.map((locale, idx) => (
+                <Tab
+                  key={locale.id}
+                  id={`locale-tab-${locale.id}`}
+                  aria-controls={`locale-panel-${locale.id}`}
+                  selected={activeLocaleTab === idx}
+                  onClick={() => setActiveLocaleTab(idx)}
+                  label={locale.title}
+                />
+              ))}
+            </TabList>
+            {locales.map((locale, idx) => (
+              <TabPanel
+                key={locale.id}
+                id={`locale-panel-${locale.id}`}
+                aria-labelledby={`locale-tab-${locale.id}`}
+                hidden={activeLocaleTab !== idx}
+              >
+                <Stack space={3}>
+                  <FormFieldInputText
+                    {...register(`title.${locale.id}` as const)}
+                    disabled={formUpdating}
+                    error={errors?.title?.[locale.id]?.message}
+                    label="Title"
+                    name={`title.${locale.id}`}
+                    value={currentAsset?.title?.[locale.id]}
+                  />
+                  <FormFieldInputText
+                    {...register(`altText.${locale.id}` as const)}
+                    disabled={formUpdating}
+                    error={errors?.altText?.[locale.id]?.message}
+                    label="Alt Text"
+                    name={`altText.${locale.id}`}
+                    value={currentAsset?.altText?.[locale.id]}
+                  />
+                  <FormFieldInputTextarea
+                    {...register(`description.${locale.id}` as const)}
+                    disabled={formUpdating}
+                    error={errors?.description?.[locale.id]?.message}
+                    label="Description"
+                    name={`description.${locale.id}`}
+                    rows={5}
+                    value={currentAsset?.description?.[locale.id]}
+                  />
+                  {creditLine?.enabled && (
+                    <FormFieldInputText
+                      {...register(`creditLine.${locale.id}` as const)}
+                      error={errors?.creditLine?.[locale.id]?.message}
+                      label="Credit"
+                      name={`creditLine.${locale.id}`}
+                      value={currentAsset?.creditLine?.[locale.id]}
+                      disabled={
+                        formUpdating ||
+                        creditLine?.excludeSources?.includes(currentAsset?.source?.name)
+                      }
+                    />
+                  )}
+                </Stack>
+              </TabPanel>
+            ))}
+          </Stack>
+        </Card>
       ) : (
-        <FormFieldInputText
-          {...register('title')}
-          disabled={formUpdating}
-          error={errors?.title?.message}
-          label="Title"
-          name="title"
-          value={currentAsset?.title}
-        />
-      )}
-      {/* Alt text */}
-      {hasLocales ? (
-        locales.map(locale => (
+        <>
           <FormFieldInputText
-            key={locale.id}
-            {...register(`altText.${locale.id}` as const)}
+            {...register('title')}
             disabled={formUpdating}
-            error={errors?.altText?.[locale.id]?.message}
-            label={`Alt Text (${locale.title})`}
-            name={`altText.${locale.id}`}
-            value={currentAsset?.altText?.[locale.id]}
+            error={errors?.title?.message}
+            label="Title"
+            name="title"
+            value={currentAsset?.title}
           />
-        ))
-      ) : (
-        <FormFieldInputText
-          {...register('altText')}
-          disabled={formUpdating}
-          error={errors?.altText?.message}
-          label="Alt Text"
-          name="altText"
-          value={currentAsset?.altText}
-        />
-      )}
-      {/* Description */}
-      {hasLocales ? (
-        locales.map(locale => (
+          <FormFieldInputText
+            {...register('altText')}
+            disabled={formUpdating}
+            error={errors?.altText?.message}
+            label="Alt Text"
+            name="altText"
+            value={currentAsset?.altText}
+          />
           <FormFieldInputTextarea
-            key={locale.id}
-            {...register(`description.${locale.id}` as const)}
+            {...register('description')}
             disabled={formUpdating}
-            error={errors?.description?.[locale.id]?.message}
-            label={`Description (${locale.title})`}
-            name={`description.${locale.id}`}
+            error={errors?.description?.message}
+            label="Description"
+            name="description"
             rows={5}
-            value={currentAsset?.description?.[locale.id]}
+            value={currentAsset?.description}
           />
-        ))
-      ) : (
-        <FormFieldInputTextarea
-          {...register('description')}
-          disabled={formUpdating}
-          error={errors?.description?.message}
-          label="Description"
-          name="description"
-          rows={5}
-          value={currentAsset?.description}
-        />
-      )}
-      {/* CreditLine */}
-      {creditLine?.enabled &&
-        (hasLocales ? (
-          locales.map(locale => (
+          {creditLine?.enabled && (
             <FormFieldInputText
-              key={locale.id}
-              {...register(`creditLine.${locale.id}` as const)}
-              error={errors?.creditLine?.[locale.id]?.message}
-              label={`Credit (${locale.title})`}
-              name={`creditLine.${locale.id}`}
-              value={currentAsset?.creditLine?.[locale.id]}
+              {...register('creditLine')}
+              error={errors?.creditLine?.message}
+              label="Credit"
+              name="creditLine"
+              value={currentAsset?.creditLine}
               disabled={
                 formUpdating || creditLine?.excludeSources?.includes(currentAsset?.source?.name)
               }
             />
-          ))
-        ) : (
-          <FormFieldInputText
-            {...register('creditLine')}
-            error={errors?.creditLine?.message}
-            label="Credit"
-            name="creditLine"
-            value={currentAsset?.creditLine}
-            disabled={
-              formUpdating || creditLine?.excludeSources?.includes(currentAsset?.source?.name)
-            }
-          />
-        ))}
+          )}
+        </>
+      )}
     </Stack>
   )
 }

--- a/src/components/DialogAssetEdit/Details.tsx
+++ b/src/components/DialogAssetEdit/Details.tsx
@@ -1,7 +1,10 @@
 import {Card, Stack, Tab, TabList, TabPanel} from '@sanity/ui'
 import {useState} from 'react'
-import type {Asset, AssetFormData, TagSelectOption} from '../../types'
 import {type Control, type FieldErrors, type UseFormRegister} from 'react-hook-form'
+import type {Asset, AssetFormData, Locale, TagSelectOption} from '../../types'
+import FormFieldInputTags from '../FormFieldInputTags'
+import FormFieldInputText from '../FormFieldInputText'
+import FormFieldInputTextarea from '../FormFieldInputTextarea'
 
 type LocalizedErrors = Record<string, {message?: string} | undefined>
 
@@ -14,10 +17,6 @@ function toStringField(value: unknown): string | undefined {
   }
   return undefined
 }
-
-import FormFieldInputTags from '../FormFieldInputTags'
-import FormFieldInputText from '../FormFieldInputText'
-import FormFieldInputTextarea from '../FormFieldInputTextarea'
 
 export type DetailsProps = {
   formUpdating: boolean
@@ -32,7 +31,7 @@ export type DetailsProps = {
     enabled: boolean
     excludeSources?: string | string[] | undefined
   }
-  locales?: {id: string; title: string}[]
+  locales?: Locale[]
 }
 
 export default function Details({

--- a/src/components/DialogAssetEdit/Details.tsx
+++ b/src/components/DialogAssetEdit/Details.tsx
@@ -5,6 +5,16 @@ import {type Control, type FieldErrors, type UseFormRegister} from 'react-hook-f
 
 type LocalizedErrors = Record<string, {message?: string} | undefined>
 
+// When locales are not configured, extract a plain string from a potentially localized field
+function toStringField(value: unknown): string | undefined {
+  if (typeof value === 'string') return value
+  if (typeof value === 'object' && value !== null) {
+    const found = Object.values(value as Record<string, string>).find(v => v)
+    return found || undefined
+  }
+  return undefined
+}
+
 import FormFieldInputTags from '../FormFieldInputTags'
 import FormFieldInputText from '../FormFieldInputText'
 import FormFieldInputTextarea from '../FormFieldInputTextarea'
@@ -133,7 +143,7 @@ export default function Details({
             error={errors?.title?.message}
             label="Title"
             name="title"
-            value={currentAsset?.title}
+            value={toStringField(currentAsset?.title)}
           />
           <FormFieldInputText
             {...register('altText')}
@@ -141,7 +151,7 @@ export default function Details({
             error={errors?.altText?.message}
             label="Alt Text"
             name="altText"
-            value={currentAsset?.altText}
+            value={toStringField(currentAsset?.altText)}
           />
           <FormFieldInputTextarea
             {...register('description')}
@@ -150,7 +160,7 @@ export default function Details({
             label="Description"
             name="description"
             rows={5}
-            value={currentAsset?.description}
+            value={toStringField(currentAsset?.description)}
           />
           {creditLine?.enabled && (
             <FormFieldInputText
@@ -158,7 +168,7 @@ export default function Details({
               error={errors?.creditLine?.message}
               label="Credit"
               name="creditLine"
-              value={currentAsset?.creditLine}
+              value={toStringField(currentAsset?.creditLine)}
               disabled={
                 formUpdating || creditLine?.excludeSources?.includes(currentAsset?.source?.name)
               }

--- a/src/components/DialogAssetEdit/Details.tsx
+++ b/src/components/DialogAssetEdit/Details.tsx
@@ -3,6 +3,8 @@ import {useState} from 'react'
 import type {Asset, AssetFormData, TagSelectOption} from '../../types'
 import {type Control, type FieldErrors, type UseFormRegister} from 'react-hook-form'
 
+type LocalizedErrors = Record<string, {message?: string} | undefined>
+
 import FormFieldInputTags from '../FormFieldInputTags'
 import FormFieldInputText from '../FormFieldInputText'
 import FormFieldInputTextarea from '../FormFieldInputTextarea'
@@ -87,35 +89,31 @@ export default function Details({
                   <FormFieldInputText
                     {...register(`title.${locale.id}` as const)}
                     disabled={formUpdating}
-                    error={errors?.title?.[locale.id]?.message}
+                    error={(errors?.title as LocalizedErrors)?.[locale.id]?.message}
                     label="Title"
                     name={`title.${locale.id}`}
-                    value={currentAsset?.title?.[locale.id]}
                   />
                   <FormFieldInputText
                     {...register(`altText.${locale.id}` as const)}
                     disabled={formUpdating}
-                    error={errors?.altText?.[locale.id]?.message}
+                    error={(errors?.altText as LocalizedErrors)?.[locale.id]?.message}
                     label="Alt Text"
                     name={`altText.${locale.id}`}
-                    value={currentAsset?.altText?.[locale.id]}
                   />
                   <FormFieldInputTextarea
                     {...register(`description.${locale.id}` as const)}
                     disabled={formUpdating}
-                    error={errors?.description?.[locale.id]?.message}
+                    error={(errors?.description as LocalizedErrors)?.[locale.id]?.message}
                     label="Description"
                     name={`description.${locale.id}`}
                     rows={5}
-                    value={currentAsset?.description?.[locale.id]}
                   />
                   {creditLine?.enabled && (
                     <FormFieldInputText
                       {...register(`creditLine.${locale.id}` as const)}
-                      error={errors?.creditLine?.[locale.id]?.message}
+                      error={(errors?.creditLine as LocalizedErrors)?.[locale.id]?.message}
                       label="Credit"
                       name={`creditLine.${locale.id}`}
-                      value={currentAsset?.creditLine?.[locale.id]}
                       disabled={
                         formUpdating ||
                         creditLine?.excludeSources?.includes(currentAsset?.source?.name)

--- a/src/components/DialogAssetEdit/index.tsx
+++ b/src/components/DialogAssetEdit/index.tsx
@@ -1,9 +1,9 @@
 import {zodResolver} from '@hookform/resolvers/zod'
 import type {MutationEvent} from '@sanity/client'
-import {Box, Button, Card, Flex, Tab, TabList, TabPanel, Text} from '@sanity/ui'
+import {Box, Button, Card, Flex, Stack, Tab, TabList, TabPanel, Text} from '@sanity/ui'
 import type {Asset, AssetFormData, DialogAssetEditProps, TagSelectOption} from '../../types'
 import groq from 'groq'
-import {type ReactNode, useCallback, useEffect, useRef, useState} from 'react'
+import {type ReactNode, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {type SubmitHandler, useForm} from 'react-hook-form'
 import {useDispatch} from 'react-redux'
 import {WithReferringDocuments, useColorSchemeValue, useDocumentStore} from 'sanity'
@@ -157,6 +157,55 @@ const DialogAssetEdit = (props: Props) => {
     [currentAsset?._id, dispatch]
   )
 
+  // Detect if asset has localized fields (objects) with keys not in the configured locales
+  const hasOrphanedLocales = useMemo(() => {
+    if (!currentAsset) return false
+    const isLocaleObj = (v: unknown) =>
+      typeof v === 'object' && v !== null && !Array.isArray(v)
+    const fields = [
+      currentAsset.title,
+      currentAsset.altText,
+      currentAsset.description,
+      currentAsset.creditLine
+    ]
+    const anyLocalized = fields.some(f => isLocaleObj(f))
+    if (!anyLocalized) return false
+    if (!locales || locales.length === 0) return true
+    const configuredIds = new Set(locales.map(l => l.id))
+    return fields.some(f => {
+      if (!isLocaleObj(f)) return false
+      return Object.keys(f as object).some(k => !configuredIds.has(k))
+    })
+  }, [currentAsset, locales])
+
+  const handleCleanupLocales = useCallback(async () => {
+    if (!currentAsset) return
+
+    const cleanField = (field: unknown): unknown => {
+      if (typeof field !== 'object' || field === null || Array.isArray(field)) return field
+      const obj = field as Record<string, string>
+      if (!locales || locales.length === 0) {
+        return Object.values(obj)[0] || ''
+      }
+      const configuredIds = new Set(locales.map(l => l.id))
+      const cleaned: Record<string, string> = {}
+      for (const [key, val] of Object.entries(obj)) {
+        if (configuredIds.has(key)) cleaned[key] = val
+      }
+      return cleaned
+    }
+
+    await client
+      .patch(currentAsset._id)
+      .set({
+        title: cleanField(currentAsset.title),
+        altText: cleanField(currentAsset.altText),
+        description: cleanField(currentAsset.description),
+        creditLine: cleanField(currentAsset.creditLine)
+      })
+      .commit()
+  }, [client, currentAsset, locales])
+
   // Submit react-hook-form
   const onSubmit: SubmitHandler<AssetFormData> = useCallback(
     formData => {
@@ -238,25 +287,44 @@ const DialogAssetEdit = (props: Props) => {
 
   const Footer = () => (
     <Box padding={3}>
-      <Flex justify="space-between">
-        {/* Delete button */}
-        <Button
-          disabled={formUpdating}
-          fontSize={1}
-          mode="bleed"
-          onClick={handleDelete}
-          text="Delete"
-          tone="critical"
-        />
+      <Stack space={3}>
+        {hasOrphanedLocales && (
+          <Card padding={3} radius={2} shadow={1} tone="caution">
+            <Flex align="center" justify="space-between" gap={3}>
+              <Text size={1}>
+                This asset has localized fields that are no longer configured. Clean them up to
+                avoid validation errors.
+              </Text>
+              <Button
+                fontSize={1}
+                mode="ghost"
+                onClick={handleCleanupLocales}
+                text="Cleanup localized fields"
+                tone="caution"
+              />
+            </Flex>
+          </Card>
+        )}
+        <Flex justify="space-between">
+          {/* Delete button */}
+          <Button
+            disabled={formUpdating}
+            fontSize={1}
+            mode="bleed"
+            onClick={handleDelete}
+            text="Delete"
+            tone="critical"
+          />
 
-        {/* Submit button */}
-        <FormSubmitButton
-          disabled={formUpdating || !isDirty || !isValid}
-          isValid={isValid}
-          lastUpdated={currentAsset?._updatedAt}
-          onClick={handleSubmit(onSubmit)}
-        />
-      </Flex>
+          {/* Submit button */}
+          <FormSubmitButton
+            disabled={formUpdating || !isDirty || !isValid}
+            isValid={isValid}
+            lastUpdated={currentAsset?._updatedAt}
+            onClick={handleSubmit(onSubmit)}
+          />
+        </Flex>
+      </Stack>
     </Box>
   )
 

--- a/src/components/DialogAssetEdit/index.tsx
+++ b/src/components/DialogAssetEdit/index.tsx
@@ -90,13 +90,22 @@ const DialogAssetEdit = (props: Props) => {
           title: makeLocaleObj(asset?.title)
         }
       }
+      // Normalize: if a field is a localized object but locales are disabled, pick first non-empty value
+      const flattenField = (field: unknown): string => {
+        if (typeof field === 'string') return field
+        if (typeof field === 'object' && field !== null) {
+          const values = Object.values(field as Record<string, string>)
+          return values.find(v => v) || ''
+        }
+        return ''
+      }
       return {
-        altText: asset?.altText || '',
-        creditLine: asset?.creditLine || '',
-        description: asset?.description || '',
+        altText: flattenField(asset?.altText),
+        creditLine: flattenField(asset?.creditLine),
+        description: flattenField(asset?.description),
         originalFilename: asset?.originalFilename || '',
         opt: {media: {tags: assetTagOptions}},
-        title: asset?.title || ''
+        title: flattenField(asset?.title)
       }
     },
     [assetTagOptions, locales]
@@ -185,7 +194,9 @@ const DialogAssetEdit = (props: Props) => {
       if (typeof field !== 'object' || field === null || Array.isArray(field)) return field
       const obj = field as Record<string, string>
       if (!locales || locales.length === 0) {
-        return Object.values(obj)[0] || ''
+        // Pick the first non-empty value sorted by key for determinism
+        const sorted = Object.keys(obj).sort()
+        return sorted.map(k => obj[k]).find(v => v) || ''
       }
       const configuredIds = new Set(locales.map(l => l.id))
       const cleaned: Record<string, string> = {}
@@ -318,7 +329,7 @@ const DialogAssetEdit = (props: Props) => {
 
           {/* Submit button */}
           <FormSubmitButton
-            disabled={formUpdating || !isDirty || !isValid}
+            disabled={formUpdating || !isDirty || !isValid || hasOrphanedLocales}
             isValid={isValid}
             lastUpdated={currentAsset?._updatedAt}
             onClick={handleSubmit(onSubmit)}

--- a/src/components/DialogAssetEdit/index.tsx
+++ b/src/components/DialogAssetEdit/index.tsx
@@ -70,11 +70,14 @@ const DialogAssetEdit = (props: Props) => {
       if (locales && locales.length > 0) {
         const makeLocaleObj = (field?: Record<string, string> | string) => {
           const obj: Record<string, string> = {}
-          for (const locale of locales) {
+          for (let i = 0; i < locales.length; i++) {
+            const locale = locales[i]
             if (typeof field === 'object' && field && field[locale.id]) {
               obj[locale.id] = field[locale.id]
             } else if (typeof field === 'string') {
-              obj[locale.id] = field
+              // Only populate the first locale to avoid spreading a legacy value
+              // across all languages; the user should fill in other translations manually
+              obj[locale.id] = i === 0 ? field : ''
             } else {
               obj[locale.id] = ''
             }
@@ -175,7 +178,7 @@ const DialogAssetEdit = (props: Props) => {
       currentAsset.title,
       currentAsset.altText,
       currentAsset.description,
-      currentAsset.creditLine
+      ...(currentAsset._type === 'sanity.imageAsset' ? [currentAsset.creditLine] : [])
     ]
     const anyLocalized = fields.some(f => isLocaleObj(f))
     if (!anyLocalized) return false
@@ -212,7 +215,9 @@ const DialogAssetEdit = (props: Props) => {
         title: cleanField(currentAsset.title),
         altText: cleanField(currentAsset.altText),
         description: cleanField(currentAsset.description),
-        creditLine: cleanField(currentAsset.creditLine)
+        ...(currentAsset._type === 'sanity.imageAsset' && {
+          creditLine: cleanField(currentAsset.creditLine)
+        })
       })
       .commit()
   }, [client, currentAsset, locales])

--- a/src/contexts/ToolOptionsContext.tsx
+++ b/src/contexts/ToolOptionsContext.tsx
@@ -1,4 +1,4 @@
-import type {MediaToolOptions} from '../types'
+import type {MediaToolOptions, Locale} from '../types'
 import {type PropsWithChildren, createContext, useContext, useMemo} from 'react'
 import type {DropzoneOptions} from 'react-dropzone'
 
@@ -7,6 +7,7 @@ type ContextProps = {
   components: MediaToolOptions['components']
   creditLine: MediaToolOptions['creditLine']
   directUploads: MediaToolOptions['directUploads']
+  locales?: Locale[]
 }
 
 const ToolOptionsContext = createContext<ContextProps | null>(null)
@@ -34,7 +35,8 @@ export const ToolOptionsProvider = ({options, children}: PropsWithChildren<Props
         enabled: options?.creditLine?.enabled || false,
         excludeSources: creditLineExcludeSources
       },
-      directUploads: options?.directUploads ?? true
+      directUploads: options?.directUploads ?? true,
+      locales: options?.locales
     }
   }, [
     options?.creditLine?.enabled,

--- a/src/contexts/ToolOptionsContext.tsx
+++ b/src/contexts/ToolOptionsContext.tsx
@@ -43,7 +43,8 @@ export const ToolOptionsProvider = ({options, children}: PropsWithChildren<Props
     options?.components,
     options?.creditLine?.excludeSources,
     options?.maximumUploadSize,
-    options?.directUploads
+    options?.directUploads,
+    options?.locales
   ])
 
   return <ToolOptionsContext.Provider value={value}>{children}</ToolOptionsContext.Provider>

--- a/src/formSchema/index.ts
+++ b/src/formSchema/index.ts
@@ -1,22 +1,36 @@
 import * as z from 'zod'
 
+// Helper to generate localized string schema
+export function localizedStringSchema(locales?: {id: string}[]) {
+  if (!locales || locales.length === 0) {
+    return z.string().trim().optional()
+  }
+  const shape: Record<string, z.ZodTypeAny> = {}
+  for (const locale of locales) {
+    shape[locale.id] = z.string().trim().optional()
+  }
+  return z.object(shape)
+}
+
 export const tagOptionSchema = z.object({
   label: z.string().trim().min(1, {message: 'Label cannot be empty'}),
   value: z.string().trim().min(1, {message: 'Value cannot be empty'})
 })
 
-export const assetFormSchema = z.object({
-  altText: z.string().trim().optional(),
-  creditLine: z.string().trim().optional(),
-  description: z.string().trim().optional(),
-  opt: z.object({
-    media: z.object({
-      tags: z.array(tagOptionSchema).nullable()
-    })
-  }),
-  originalFilename: z.string().trim().min(1, {message: 'Filename cannot be empty'}),
-  title: z.string().trim().optional()
-})
+export function getAssetFormSchema(locales?: {id: string}[]) {
+  return z.object({
+    altText: localizedStringSchema(locales),
+    creditLine: localizedStringSchema(locales),
+    description: localizedStringSchema(locales),
+    opt: z.object({
+      media: z.object({
+        tags: z.array(tagOptionSchema).nullable()
+      })
+    }),
+    originalFilename: z.string().trim().min(1, {message: 'Filename cannot be empty'}),
+    title: localizedStringSchema(locales)
+  })
+}
 
 export const tagFormSchema = z.object({
   name: z.string().min(1, {message: 'Name cannot be empty'})

--- a/src/formSchema/index.ts
+++ b/src/formSchema/index.ts
@@ -9,7 +9,7 @@ export function localizedStringSchema(locales?: {id: string}[]) {
   for (const locale of locales) {
     shape[locale.id] = z.string().trim().optional()
   }
-  return z.object(shape)
+  return z.object(shape).passthrough()
 }
 
 export const tagOptionSchema = z.object({

--- a/src/formSchema/index.ts
+++ b/src/formSchema/index.ts
@@ -32,6 +32,8 @@ export function getAssetFormSchema(locales?: {id: string}[]) {
   })
 }
 
+export const assetFormSchema = getAssetFormSchema()
+
 export const tagFormSchema = z.object({
   name: z.string().min(1, {message: 'Name cannot be empty'})
 })

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,6 +37,7 @@ export type MediaToolOptions = {
 export type Locale = {
   title: string
   id: string
+  [key: string]: any // Allow extra keys (e.g. isDefault)
 }
 
 type CustomFields = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,11 +22,21 @@ export type MediaToolOptions = {
       DetailsProps & {renderDefaultDetails: (props: DetailsProps) => JSX.Element}
     >
   }
-  creditLine: {
+  creditLine?: {
     enabled: boolean
     excludeSources?: string | string[]
   }
   directUploads?: boolean
+  /**
+   * Optional locales following Sanity recommended scheme: [{ id, title }]
+   * https://www.sanity.io/docs/studio/localization#k4da239411955
+   */
+  locales?: Locale[]
+}
+
+export type Locale = {
+  title: string
+  id: string
 }
 
 type CustomFields = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,7 +51,6 @@ type CustomFields = {
     }
   }
   title?: LocalizedString
-  creditLine?: LocalizedString
 }
 
 type SearchFacetInputCommon = {
@@ -181,7 +180,7 @@ export type FileAsset = SanityAssetDocument &
 export type ImageAsset = SanityImageAssetDocument &
   CustomFields & {
     _type: 'sanity.imageAsset'
-    creditLine?: string
+    creditLine?: LocalizedString
   }
 
 export type MarkDef = {_key: string; _type: string}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,7 +37,7 @@ export type MediaToolOptions = {
 export type Locale = {
   title: string
   id: string
-  [key: string]: any // Allow extra keys (e.g. isDefault)
+  [key: string]: unknown
 }
 
 type CustomFields = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,7 +8,7 @@ import type {
 import type {ComponentType, JSX} from 'react'
 import type {Epic} from 'redux-observable'
 import * as z from 'zod'
-import {assetFormSchema, tagFormSchema, tagOptionSchema} from '../formSchema'
+import {getAssetFormSchema, tagFormSchema, tagOptionSchema} from '../formSchema'
 import type {RootReducerState} from '../modules/types'
 import type {DetailsProps} from '../components/DialogAssetEdit/Details'
 import type {SUPPORTED_ASSET_TYPES} from '../constants'
@@ -40,15 +40,18 @@ export type Locale = {
   [key: string]: unknown
 }
 
+type LocalizedString = string | Record<string, string>
+
 type CustomFields = {
-  altText?: string
-  description?: string
+  altText?: LocalizedString
+  description?: LocalizedString
   opt?: {
     media?: {
       tags?: SanityReference[]
     }
   }
-  title?: string
+  title?: LocalizedString
+  creditLine?: LocalizedString
 }
 
 type SearchFacetInputCommon = {
@@ -62,7 +65,7 @@ type SearchFacetInputCommon = {
 
 export type Asset = FileAsset | ImageAsset
 
-export type AssetFormData = z.infer<typeof assetFormSchema>
+export type AssetFormData = z.infer<ReturnType<typeof getAssetFormSchema>>
 
 export type AssetItem = {
   _type: 'asset'


### PR DESCRIPTION
### Description

This PR adds full support for localized asset fields in the media plugin, following Sanity's recommended localization scheme. Now, if a `locale` array is provided in the plugin config, all localizable fields (title, altText, description, creditLine) are shown in language-specific tabs, allowing editors to enter translations for each language. The implementation is compatible with objects containing extra keys (e.g. isDefault), but only `id` and `title` are used internally.

<img width="1915" height="948" alt="Cattura" src="https://github.com/user-attachments/assets/36f72fb7-9fad-4e6c-b770-77927de7c8b0" />

### What to review
- The new tabbed UI for localized fields in the asset edit dialog.
- The dynamic schema and form logic for handling both localized and non-localized setups.
- TypeScript compatibility with extended locale objects.
- Documentation updates, including usage, config, and fallback handling.

### Testing
- Manual testing with various locales arrays (including with extra keys like isDefault).
- Verified that fields are grouped by language in tabs and fallback logic is left to the user (with a GROQ example in the README).
- No automated tests were added, but the changes are isolated to the plugin’s asset field handling and UI.

Closes #265 
