### PR TITLE
feat: show svg thumbnails

### DIFF
--- a/src/components/CardAsset/index.tsx
+++ b/src/components/CardAsset/index.tsx
@@ -170,9 +170,14 @@ const CardAsset = (props: Props) => {
               <Image
                 draggable={false}
                 $scheme={scheme}
-                $showCheckerboard={!isOpaque}
-                src={imageDprUrl(asset, {height: 250, width: 250})}
+                $showCheckerboard={asset.mimeType !== 'image/svg+xml' && !isOpaque}
+                src={
+                  asset.mimeType === 'image/svg+xml'
+                    ? asset.url
+                    : imageDprUrl(asset, {height: 250, width: 250})
+                }
                 style={{
+                  ...(asset.mimeType === 'image/svg+xml' && {backgroundColor: 'white'}),
                   draggable: false,
                   transition: 'opacity 1000ms'
                 }}

--- a/src/components/TableRowAsset/index.tsx
+++ b/src/components/TableRowAsset/index.tsx
@@ -239,8 +239,13 @@ const TableRowAsset = (props: Props) => {
               <Image
                 draggable={false}
                 $scheme={scheme}
-                $showCheckerboard={!isOpaque}
-                src={imageDprUrl(asset, {height: 100, width: 100})}
+                $showCheckerboard={asset.mimeType !== 'image/svg+xml' && !isOpaque}
+                src={
+                  asset.mimeType === 'image/svg+xml'
+                    ? asset.url
+                    : imageDprUrl(asset, {height: 100, width: 100})
+                }
+                style={asset.mimeType === 'image/svg+xml' ? {backgroundColor: 'white'} : undefined}
               />
             )}
           </Box>


### PR DESCRIPTION
### Description

Add image based preview thumbnails for svg images

### What to review

When viewing thumbnails in the gallery view, you should get a preview of the actual image, not a generic SVG icon.

### Testing

No tests added at this stage, but if this is something you are willing to accept I'm happy to add some.

#### Related
https://github.com/sanity-io/sanity-plugin-media/issues/286