### PR TITLE
chore: setup vitest and test the main plugin actions, components and utils

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,30 @@ module.exports = {
     'plugin:prettier/recommended',
     'plugin:react/jsx-runtime'
   ],
+  overrides: [
+    {
+      files: [
+        '**/*.test.ts',
+        '**/*.test.tsx',
+        'vitest.setup.ts',
+        'vitest.config.ts',
+        'src/__tests__/**/*.ts',
+        'src/__tests__/**/*.tsx'
+      ],
+      env: {
+        node: true
+      },
+      globals: {
+        afterEach: 'readonly',
+        beforeEach: 'readonly',
+        describe: 'readonly',
+        expect: 'readonly',
+        it: 'readonly',
+        test: 'readonly',
+        vi: 'readonly'
+      }
+    }
+  ],
   rules: {
     '@typescript-eslint/explicit-function-return-type': 0,
     'react/react-in-jsx-scope': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
         beforeEach: 'readonly',
         describe: 'readonly',
         expect: 'readonly',
+        globalThis: 'readonly',
         it: 'readonly',
         test: 'readonly',
         vi: 'readonly'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+---
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version: lts/*
+      - run: npm ci
+      - run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,9 @@
         "@sanity/plugin-kit": "^4.0.19",
         "@sanity/semantic-release-preset": "^2.0.5",
         "@sanity/vision": "^3.80.1",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.2.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/is-hotkey": "^0.1.10",
         "@types/pluralize": "^0.0.33",
         "@types/react": "^19.0.12",
@@ -58,6 +61,7 @@
         "eslint-plugin-react": "^7.37.4",
         "eslint-plugin-react-hooks": "^4.6.2",
         "husky": "^8.0.2",
+        "jsdom": "^25.0.1",
         "lint-staged": "^13.0.3",
         "prettier": "^2.8.8",
         "prettier-plugin-packagejson": "^2.5.10",
@@ -68,7 +72,8 @@
         "sanity": "^3.80.1",
         "standard-version": "^9.5.0",
         "styled-components": "^6.1.16",
-        "typescript": "5.8.2"
+        "typescript": "5.8.2",
+        "vitest": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -134,7 +139,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -306,6 +310,13 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
       "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
     },
@@ -607,7 +618,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2468,7 +2478,6 @@
       "integrity": "sha512-xMF6OfEAUVY5Waega4juo1QGACfNkNF+aJLqpd8oUJz96ms2zbfQ9Gh35/tI3y8akEV31FruKfj7hBnIU/nkqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -2649,6 +2658,13 @@
       "engines": {
         "node": ">=v14"
       }
+    },
+    "node_modules/@commitlint/load/node_modules/@types/node": {
+      "version": "20.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
+      "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@commitlint/message": {
       "version": "17.8.1",
@@ -2875,7 +2891,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2899,7 +2914,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2937,7 +2951,6 @@
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3083,7 +3096,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
       "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -4861,7 +4873,6 @@
       "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -6679,7 +6690,6 @@
       "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.13.2.tgz",
       "integrity": "sha512-bXuQGWgrpkSInZy8lfCMmOgdTNpsoZ7PORW0+zXss8qVpNo1DC002l1c8to6kfxNF0OaL9v7LwsPqKcTZ/VWrw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
         "get-it": "^8.7.0",
@@ -8002,7 +8012,6 @@
       "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -8509,7 +8518,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8631,7 +8639,6 @@
       "integrity": "sha512-L0b0Tl3RfoVZM5gYdG8WSLOjlGcJ/xWALz5dkx2bPgnCDVYt3YZDrVO/mzRiSor0cO8i4iU35CKS3tBuXbeZTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sanity/descriptors": "^1.1.1",
         "@sanity/generate-help-url": "^3.0.0",
@@ -8768,7 +8775,6 @@
       "integrity": "sha512-a766U9VSoyOSWq+RZz9wsEo/Nnn+inDkEcdGu+rHFuygdepullB/RZpF2MxNsfUMCSPnajgG1Tm9lhwbSmlySA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sanity/client": "^7.6.0",
         "@sanity/media-library-types": "^1.0.0"
@@ -9676,6 +9682,96 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -9722,13 +9818,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -9767,6 +9870,24 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -9845,11 +9966,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.5.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
-      "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -9889,7 +10012,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz",
       "integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -10051,7 +10173,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -10361,6 +10482,94 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xstate/react": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@xstate/react/-/react-6.0.0.tgz",
@@ -10400,7 +10609,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10814,6 +11022,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -10982,6 +11200,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-kit": {
@@ -11360,7 +11588,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11623,6 +11850,23 @@
         "react": ">=17.0.0"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -11692,6 +11936,16 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -13102,7 +13356,6 @@
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -13311,6 +13564,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -13849,6 +14109,16 @@
         "node": ">= 16"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -13982,6 +14252,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-indent": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.1.tgz",
@@ -14091,6 +14371,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -14587,9 +14875,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -14660,7 +14948,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -14755,7 +15042,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -15264,6 +15550,16 @@
       "integrity": "sha512-FXnmK9yJYTa3V3G7DE9BRjUJ0pwXMICAxfbsAuKPTuSlFzMZhQbcvvwx0I8ofNJHxz3tfjze+whxcGpfklAWOQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -17374,7 +17670,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -18409,19 +18704,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/isomorphic-dompurify/node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^6.1.32"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/issue-parser": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-6.0.0.tgz",
@@ -18514,7 +18796,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -18553,33 +18834,32 @@
       "license": "Python-2.0"
     },
     "node_modules/jsdom": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
-      "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@asamuzakjp/dom-selector": "^2.0.1",
-        "cssstyle": "^4.0.1",
+        "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
         "decimal.js": "^10.4.3",
         "form-data": "^4.0.0",
         "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
         "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
         "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.6.0",
+        "rrweb-cssom": "^0.7.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.3",
+        "tough-cookie": "^5.0.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^3.1.1",
         "whatwg-mimetype": "^4.0.0",
         "whatwg-url": "^14.0.0",
-        "ws": "^8.16.0",
+        "ws": "^8.18.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
@@ -19902,6 +20182,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -19910,6 +20197,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -19982,7 +20280,6 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -24160,6 +24457,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/peek-stream": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
@@ -24652,7 +24959,6 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -24707,6 +25013,44 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pretty-ms": {
       "version": "7.0.1",
@@ -25093,7 +25437,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25125,7 +25468,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
       "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.25.0"
       },
@@ -25200,7 +25542,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
       "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -25239,15 +25580,13 @@
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
       "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -25620,8 +25959,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-observable": {
       "version": "3.0.0-rc.2",
@@ -25996,7 +26334,6 @@
       "integrity": "sha512-iTNAbFSlRpcHeeWu73ywU/8KuU/LZmNCSxp6fjQkJBD3ivUb8tpDrXhIxEzA05HlYMEwmtaUnb3RP+YNv162OQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -26054,9 +26391,9 @@
       }
     },
     "node_modules/rrweb-cssom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
       "dev": true,
       "license": "MIT"
     },
@@ -26141,7 +26478,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -26257,7 +26593,6 @@
       "integrity": "sha512-uNo8bEC6w4j87d6mUMpkTIjRR/bTtF+SKmvRl0XP7ZCjds9oK2+t4txL1Rr0VmV5KnCFZJhq8sP7aVJN5PPD5w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^6.0.1",
@@ -27170,6 +27505,47 @@
         "node": ">=16"
       }
     },
+    "node_modules/sanity/node_modules/jsdom": {
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
+      "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^2.0.1",
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.16.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/sanity/node_modules/log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -27287,8 +27663,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/sanity/node_modules/readdirp": {
       "version": "3.6.0",
@@ -27319,6 +27694,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sanity/node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sanity/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -27332,13 +27714,38 @@
         "node": ">=4"
       }
     },
+    "node_modules/sanity/node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/sanity/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/sanity/node_modules/vite": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -27500,7 +27907,6 @@
       "integrity": "sha512-NMPKdfpXTnPn49FDogMBi36SiBfXkSOJqCkk0E4iWOY1tusvvgBwqUmxTX1kmlT6kIYed9YwNKD1sfPpqa5yaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/error": "^3.0.0",
@@ -27907,6 +28313,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -28063,7 +28476,6 @@
       "integrity": "sha512-vHfMHrb8WJ6TFfl7yLXT+UlTzdbUQHpAfdGV0tJfECvbRMAOwAKkjgtAMI8FBmJ1t6BKUgX3ybXk3Y2JxQ2R1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "immer": "^10.0.3",
         "tiny-warning": "^1.0.3"
@@ -28350,6 +28762,13 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standard-version": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.5.0.tgz",
@@ -28576,6 +28995,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -28930,6 +29356,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/style-mod": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
@@ -28942,7 +29388,6 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.16.tgz",
       "integrity": "sha512-KpWB6ORAWGmbWM10cDJfEV6sXc/uVkkkQV3SLwTNQ/E/PqWgNHIoMSLh1Lnk2FkB9+JHK7uuMq1i+9ArxDD7iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",
@@ -29300,6 +29745,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -29315,6 +29774,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -29395,29 +29884,16 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^6.1.32"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -29489,7 +29965,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -30256,7 +30731,6 @@
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -30335,6 +30809,12 @@
       "engines": {
         "node": ">=14.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -30713,6 +31193,1315 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/vite-node/node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -30929,6 +32718,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {
@@ -31433,7 +33239,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "format": "prettier --write --cache --ignore-unknown .",
     "link-watch": "plugin-kit link-watch",
     "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "husky install",
     "prepublishOnly": "npm run build",
     "watch": "pkg-utils watch --strict"
@@ -87,6 +89,9 @@
     "@sanity/plugin-kit": "^4.0.19",
     "@sanity/semantic-release-preset": "^2.0.5",
     "@sanity/vision": "^3.80.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/is-hotkey": "^0.1.10",
     "@types/pluralize": "^0.0.33",
     "@types/react": "^19.0.12",
@@ -102,6 +107,7 @@
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-hooks": "^4.6.2",
     "husky": "^8.0.2",
+    "jsdom": "^25.0.1",
     "lint-staged": "^13.0.3",
     "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.5.10",
@@ -112,7 +118,8 @@
     "sanity": "^3.80.1",
     "standard-version": "^9.5.0",
     "styled-components": "^6.1.16",
-    "typescript": "5.8.2"
+    "typescript": "5.8.2",
+    "vitest": "^3.0.5"
   },
   "peerDependencies": {
     "react": "^18.3 || ^19",

--- a/src/__tests__/fixtures/createEpicTestStore.ts
+++ b/src/__tests__/fixtures/createEpicTestStore.ts
@@ -1,0 +1,27 @@
+import {configureStore, type AnyAction, type EnhancedStore} from '@reduxjs/toolkit'
+import type {SanityClient} from '@sanity/client'
+import type {Epic} from 'redux-observable'
+import {createEpicMiddleware} from 'redux-observable'
+import {rootReducer} from '../../modules'
+import type {RootReducerState} from '../../modules/types'
+import {createTestRootState} from './rootState'
+
+export function createEpicTestStore(
+  epic: Epic<AnyAction, AnyAction, RootReducerState, {client: SanityClient}>,
+  mockClient: SanityClient,
+  preloaded?: Partial<RootReducerState>
+): EnhancedStore<RootReducerState, AnyAction> {
+  const epicMiddleware = createEpicMiddleware<AnyAction, AnyAction, RootReducerState>({
+    dependencies: {client: mockClient}
+  })
+
+  const store = configureStore({
+    reducer: rootReducer,
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({serializableCheck: false, thunk: false}).concat(epicMiddleware),
+    preloadedState: createTestRootState(preloaded)
+  })
+
+  epicMiddleware.run(epic)
+  return store
+}

--- a/src/__tests__/fixtures/listenMock.ts
+++ b/src/__tests__/fixtures/listenMock.ts
@@ -1,0 +1,9 @@
+import {vi} from 'vitest'
+
+/** Flat mock for client.listen() without deep callback nesting (ESLint max-nested-callbacks). */
+export function createListenMock(): ReturnType<typeof vi.fn> {
+  const unsubscribe = vi.fn()
+  const subscribe = vi.fn()
+  subscribe.mockReturnValue({unsubscribe})
+  return vi.fn().mockReturnValue({subscribe})
+}

--- a/src/__tests__/fixtures/mockSanityClient.ts
+++ b/src/__tests__/fixtures/mockSanityClient.ts
@@ -1,0 +1,84 @@
+import type {SanityClient} from '@sanity/client'
+import {Subject, of} from 'rxjs'
+import {vi} from 'vitest'
+
+export type MockSanityClient = {
+  observable: {
+    fetch: ReturnType<typeof vi.fn>
+    delete: ReturnType<typeof vi.fn>
+    create: ReturnType<typeof vi.fn>
+    assets: {upload: ReturnType<typeof vi.fn>}
+  }
+  fetch: ReturnType<typeof vi.fn>
+  listen: ReturnType<typeof vi.fn>
+  patch: ReturnType<typeof vi.fn>
+  transaction: ReturnType<typeof vi.fn>
+}
+
+export function createMockSanityClient(
+  overrides: Partial<Omit<MockSanityClient, 'observable'>> & {
+    observable?: Partial<MockSanityClient['observable']> & {
+      assets?: Partial<MockSanityClient['observable']['assets']>
+    }
+  } = {}
+): SanityClient {
+  const {observable: observableOverrides, ...restOverrides} = overrides
+
+  const observableBase: MockSanityClient['observable'] = {
+    fetch: vi.fn(() => of({items: []})),
+    delete: vi.fn(() => of({})),
+    create: vi.fn(() => of({_id: 'new'})),
+    assets: {
+      upload: vi.fn(() => of({type: 'complete', body: {document: {_id: 'up'}}}))
+    }
+  }
+
+  const observable: MockSanityClient['observable'] = {
+    ...observableBase,
+    ...(observableOverrides ?? {}),
+    assets: {
+      ...observableBase.assets,
+      ...(observableOverrides?.assets ?? {})
+    }
+  }
+
+  const client: MockSanityClient = {
+    observable,
+    fetch: vi.fn(() => Promise.resolve(0)),
+    listen: vi.fn(() => new Subject()),
+    patch: vi.fn(),
+    transaction: vi.fn(),
+    ...restOverrides
+  }
+
+  return client as unknown as SanityClient
+}
+
+export function mockPatchChain(result: unknown): {
+  set: ReturnType<typeof vi.fn>
+  setIfMissing: ReturnType<typeof vi.fn>
+  commit: ReturnType<typeof vi.fn>
+} {
+  const commit = vi.fn().mockResolvedValue(result)
+  const chain = {
+    set: vi.fn(),
+    setIfMissing: vi.fn(),
+    commit
+  }
+  chain.set.mockImplementation(() => chain)
+  chain.setIfMissing.mockImplementation(() => chain)
+  return chain
+}
+
+export function mockTransactionCommit(resolved: unknown = undefined): {
+  patch: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+  commit: ReturnType<typeof vi.fn>
+} {
+  const tx = {
+    patch: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    commit: vi.fn().mockResolvedValue(resolved)
+  }
+  return tx
+}

--- a/src/__tests__/fixtures/renderWithProviders.tsx
+++ b/src/__tests__/fixtures/renderWithProviders.tsx
@@ -1,0 +1,54 @@
+import type {ReactElement, ReactNode} from 'react'
+import {configureStore} from '@reduxjs/toolkit'
+import {studioTheme, ThemeProvider, ToastProvider} from '@sanity/ui'
+import {ColorSchemeProvider} from 'sanity'
+import {Provider} from 'react-redux'
+import {render} from '@testing-library/react'
+import {AssetBrowserDispatchProvider} from '../../contexts/AssetSourceDispatchContext'
+import {ToolOptionsProvider} from '../../contexts/ToolOptionsContext'
+import {rootReducer} from '../../modules'
+import type {RootReducerState} from '../../modules/types'
+import type {MediaToolOptions} from '../../types'
+import {createTestRootState} from './rootState'
+import type {AssetSourceComponentProps} from 'sanity'
+
+type Opts = {
+  onSelect?: AssetSourceComponentProps['onSelect']
+  preloaded?: Partial<RootReducerState>
+  toolOptions?: Partial<MediaToolOptions>
+}
+
+export function renderWithProviders(ui: ReactElement, opts: Opts = {}) {
+  const {onSelect, preloaded, toolOptions} = opts
+
+  const store = configureStore({
+    reducer: rootReducer,
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({thunk: false, serializableCheck: false}),
+    preloadedState: createTestRootState(preloaded)
+  })
+
+  const options: MediaToolOptions = {
+    creditLine: {enabled: false},
+    directUploads: true,
+    ...toolOptions
+  }
+
+  const wrap = (node: ReactNode) => (
+    <Provider store={store}>
+      <ColorSchemeProvider scheme="light">
+        <ToolOptionsProvider options={options}>
+          <ThemeProvider theme={studioTheme}>
+            <ToastProvider>
+              <AssetBrowserDispatchProvider onSelect={onSelect}>
+                {node}
+              </AssetBrowserDispatchProvider>
+            </ToastProvider>
+          </ThemeProvider>
+        </ToolOptionsProvider>
+      </ColorSchemeProvider>
+    </Provider>
+  )
+
+  return {store, ...render(wrap(ui))}
+}

--- a/src/__tests__/fixtures/rootState.ts
+++ b/src/__tests__/fixtures/rootState.ts
@@ -1,0 +1,27 @@
+import type {RootReducerState} from '../../modules/types'
+import {initialState as assetsInitialState} from '../../modules/assets'
+
+export function createTestRootState(overrides: Partial<RootReducerState> = {}): RootReducerState {
+  const base: RootReducerState = {
+    assets: {
+      ...assetsInitialState,
+      assetTypes: ['file', 'image']
+    },
+    debug: {badConnection: false, enabled: false},
+    dialog: {items: []},
+    notifications: {items: []},
+    search: {facets: [], query: ''},
+    selected: {assets: [], document: undefined, documentAssetIds: []},
+    tags: {
+      allIds: [],
+      byIds: {},
+      creating: false,
+      fetchCount: -1,
+      fetching: false,
+      panelVisible: true
+    },
+    uploads: {allIds: [], byIds: {}}
+  }
+
+  return {...base, ...overrides} as RootReducerState
+}

--- a/src/__tests__/fixtures/withinDialog.ts
+++ b/src/__tests__/fixtures/withinDialog.ts
@@ -1,0 +1,28 @@
+import {within, type Screen} from '@testing-library/react'
+
+/** Topmost Sanity dialog matching `name` (handles animated duplicate layers). */
+export function getDialogRoot(name: RegExp, base: Screen): HTMLElement {
+  const dialogs = base.getAllByRole('dialog', {name})
+  const el = dialogs.at(-1)
+  if (!el) {
+    throw new Error(`No dialog found matching ${name}`)
+  }
+  return el
+}
+
+/** Scoped queries for that dialog. */
+export function withinDialog(name: RegExp, base: Screen) {
+  return within(getDialogRoot(name, base))
+}
+
+/**
+ * Sanity `TextInput` is not always exposed as a labellable control; use the native input by `name`.
+ */
+export function inputByName(dialogName: RegExp, base: Screen, name: string): HTMLInputElement {
+  const root = getDialogRoot(dialogName, base)
+  const input = root.querySelector(`input[name="${name}"]`)
+  if (!input || !(input instanceof HTMLInputElement)) {
+    throw new Error(`No input name="${name}" in dialog matching ${dialogName}`)
+  }
+  return input
+}

--- a/src/components/Browser/Browser.test.tsx
+++ b/src/components/Browser/Browser.test.tsx
@@ -1,0 +1,44 @@
+import {describe, expect, it, vi, beforeEach} from 'vitest'
+import {render, screen, waitFor} from '@testing-library/react'
+import {studioTheme, ThemeProvider, ToastProvider} from '@sanity/ui'
+import {ColorSchemeProvider} from 'sanity'
+import {of} from 'rxjs'
+import Browser from './index'
+import {createListenMock} from '../../__tests__/fixtures/listenMock'
+import {createMockSanityClient} from '../../__tests__/fixtures/mockSanityClient'
+import {ToolOptionsProvider} from '../../contexts/ToolOptionsContext'
+import useVersionedClient from '../../hooks/useVersionedClient'
+
+vi.mock('../../hooks/useVersionedClient', () => ({
+  default: vi.fn()
+}))
+
+describe('Browser', () => {
+  beforeEach(() => {
+    const fetch = vi.fn().mockReturnValue(of({items: []}))
+    vi.mocked(useVersionedClient).mockReturnValue(
+      createMockSanityClient({
+        listen: createListenMock(),
+        observable: {fetch}
+      })
+    )
+  })
+
+  it('renders Browse Assets header in tool mode', async () => {
+    render(
+      <ColorSchemeProvider scheme="light">
+        <ThemeProvider theme={studioTheme}>
+          <ToastProvider>
+            <ToolOptionsProvider options={{creditLine: {enabled: false}}}>
+              <Browser />
+            </ToolOptionsProvider>
+          </ToastProvider>
+        </ThemeProvider>
+      </ColorSchemeProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Browse Assets')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/CardAsset/CardAsset.test.tsx
+++ b/src/components/CardAsset/CardAsset.test.tsx
@@ -1,0 +1,314 @@
+import type {RefObject} from 'react'
+import userEvent from '@testing-library/user-event'
+import {screen} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import CardAsset from './index'
+import {renderWithProviders} from '../../__tests__/fixtures/renderWithProviders'
+import {initialState as assetsInitialState} from '../../modules/assets'
+import type {AssetItem, AssetType, FileAsset, ImageAsset} from '../../types'
+
+const SHIFT_FLAG = '__CARD_ASSET_TEST_SHIFT__'
+
+function setShiftPressed(on: boolean) {
+  const g = globalThis as unknown as Record<string, boolean | undefined>
+  if (on) {
+    g[SHIFT_FLAG] = true
+  } else {
+    delete g[SHIFT_FLAG]
+  }
+}
+
+vi.mock('../../hooks/useKeyPress', () => ({
+  default: (): RefObject<boolean> =>
+    ({
+      get current() {
+        return Boolean((globalThis as unknown as Record<string, unknown>)[SHIFT_FLAG])
+      }
+    }) as RefObject<boolean>
+}))
+
+vi.mock('../Image', () => ({
+  default: () => <div data-testid="card-image" />
+}))
+
+vi.mock('../FileIcon', () => ({
+  default: ({extension}: {extension?: string}) => (
+    <div data-testid="card-file-icon" data-extension={extension ?? ''} />
+  )
+}))
+
+vi.mock('sanity', async importOriginal => {
+  const actual = await importOriginal<typeof import('sanity')>()
+  return {
+    ...actual,
+    useColorSchemeValue: () => 'light'
+  }
+})
+
+const imageAsset = {
+  _id: 'img-1',
+  _type: 'sanity.imageAsset',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'r1',
+  originalFilename: 'photo.png',
+  size: 1,
+  mimeType: 'image/png',
+  url: 'https://example.com/photo.png',
+  metadata: {dimensions: {width: 100, height: 100}, isOpaque: true}
+} as ImageAsset
+
+const fileAsset = {
+  _id: 'file-1',
+  _type: 'sanity.fileAsset',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'r1',
+  originalFilename: 'doc.pdf',
+  extension: 'pdf',
+  size: 1,
+  mimeType: 'application/pdf',
+  url: 'https://example.com/doc.pdf'
+} as FileAsset
+
+function assetItem(asset: ImageAsset | FileAsset, partial?: Partial<AssetItem>): AssetItem {
+  return {
+    _type: 'asset',
+    asset,
+    picked: false,
+    updating: false,
+    ...partial
+  }
+}
+
+function assetsState(byIds: Record<string, AssetItem>, extra?: Partial<typeof assetsInitialState>) {
+  return {
+    ...assetsInitialState,
+    assetTypes: ['file', 'image'] as AssetType[],
+    allIds: Object.keys(byIds),
+    byIds,
+    ...extra
+  }
+}
+
+function clickPreview() {
+  const imgs = screen.getAllByTestId('card-image')
+  const img = imgs.at(-1)
+  if (!img) {
+    throw new Error('card-image missing')
+  }
+  const target = img.parentElement
+  if (!target) {
+    throw new Error('preview wrapper missing')
+  }
+  return target
+}
+
+function clickFooterFilename(text: string) {
+  const nodes = screen.getAllByText(text)
+  const el = nodes.at(-1)
+  if (!el) {
+    throw new Error(`footer text missing: ${text}`)
+  }
+  return el
+}
+
+beforeEach(() => {
+  setShiftPressed(false)
+})
+
+describe('CardAsset', () => {
+  it('renders nothing when the asset id is not in the store', () => {
+    renderWithProviders(<CardAsset id="missing" selected={false} />, {
+      preloaded: {
+        assets: assetsState({})
+      }
+    })
+    expect(screen.queryAllByTestId('card-image')).toHaveLength(0)
+    expect(screen.queryAllByTestId('card-file-icon')).toHaveLength(0)
+  })
+
+  it('renders image preview and original filename for an image asset', () => {
+    renderWithProviders(<CardAsset id="img-1" selected={false} />, {
+      preloaded: {
+        assets: assetsState({'img-1': assetItem(imageAsset)})
+      }
+    })
+    expect(screen.getAllByTestId('card-image').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('photo.png').length).toBeGreaterThan(0)
+  })
+
+  it('renders file icon with extension for a file asset', () => {
+    renderWithProviders(<CardAsset id="file-1" selected={false} />, {
+      preloaded: {
+        assets: assetsState({'file-1': assetItem(fileAsset)})
+      }
+    })
+    const icon = screen.getAllByTestId('card-file-icon').at(-1)!
+    expect(icon).toHaveAttribute('data-extension', 'pdf')
+    expect(screen.getAllByText('doc.pdf').length).toBeGreaterThan(0)
+  })
+
+  it('opens the asset edit dialog when the preview is clicked in browse mode', async () => {
+    const user = userEvent.setup()
+    const {store} = renderWithProviders(<CardAsset id="img-1" selected={false} />, {
+      preloaded: {
+        assets: assetsState({'img-1': assetItem(imageAsset)})
+      }
+    })
+
+    await user.click(clickPreview())
+
+    expect(store.getState().dialog.items.some(d => d.type === 'assetEdit' && d.assetId === 'img-1')).toBe(
+      true
+    )
+  })
+
+  it('calls onSelect with the asset document id when the preview is clicked in picker mode', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    renderWithProviders(<CardAsset id="img-1" selected={false} />, {
+      onSelect,
+      preloaded: {
+        assets: assetsState({'img-1': assetItem(imageAsset)})
+      }
+    })
+
+    await user.click(clickPreview())
+
+    expect(onSelect).toHaveBeenCalledWith([
+      {
+        kind: 'assetDocumentId',
+        value: 'img-1'
+      }
+    ])
+  })
+
+  it('toggles pick when the footer is clicked in browse mode', async () => {
+    const user = userEvent.setup()
+    const {store} = renderWithProviders(<CardAsset id="img-1" selected={false} />, {
+      preloaded: {
+        assets: assetsState({'img-1': assetItem(imageAsset, {picked: false})})
+      }
+    })
+
+    await user.click(clickFooterFilename('photo.png'))
+
+    expect(store.getState().assets.byIds['img-1'].picked).toBe(true)
+  })
+
+  it('opens asset edit from the footer when in picker mode', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    const {store} = renderWithProviders(<CardAsset id="img-1" selected={false} />, {
+      onSelect,
+      preloaded: {
+        assets: assetsState({'img-1': assetItem(imageAsset)})
+      }
+    })
+
+    await user.click(clickFooterFilename('photo.png'))
+
+    expect(onSelect).not.toHaveBeenCalled()
+    expect(store.getState().dialog.items.some(d => d.type === 'assetEdit' && d.assetId === 'img-1')).toBe(
+      true
+    )
+  })
+
+  it('shift-clicks on preview to unpick when the asset is already picked', async () => {
+    const user = userEvent.setup()
+    const {store} = renderWithProviders(<CardAsset id="img-1" selected={false} />, {
+      preloaded: {
+        assets: assetsState({'img-1': assetItem(imageAsset, {picked: true})})
+      }
+    })
+
+    setShiftPressed(true)
+    await user.click(clickPreview())
+    setShiftPressed(false)
+
+    expect(store.getState().assets.byIds['img-1'].picked).toBe(false)
+  })
+
+  it('shift-clicks on preview to pick a range when not picked and lastPicked is set', async () => {
+    const user = userEvent.setup()
+    const prevAsset = {...imageAsset, _id: 'prev-1', originalFilename: 'prev.png'} as ImageAsset
+    const {store} = renderWithProviders(<CardAsset id="img-1" selected={false} />, {
+      preloaded: {
+        assets: assetsState(
+          {
+            'prev-1': assetItem(prevAsset),
+            'img-1': assetItem(imageAsset, {picked: false})
+          },
+          {lastPicked: 'prev-1'}
+        )
+      }
+    })
+
+    setShiftPressed(true)
+    await user.click(clickPreview())
+    setShiftPressed(false)
+
+    expect(store.getState().assets.byIds['img-1'].picked).toBe(true)
+    expect(store.getState().assets.byIds['prev-1'].picked).toBe(true)
+  })
+
+  it('shift-clicks on footer to pick a range when not picked', async () => {
+    const user = userEvent.setup()
+    const anchorAsset = {...imageAsset, _id: 'anchor-9', originalFilename: 'anchor.png'} as ImageAsset
+    const {store} = renderWithProviders(<CardAsset id="img-1" selected={false} />, {
+      preloaded: {
+        assets: assetsState(
+          {
+            'anchor-9': assetItem(anchorAsset),
+            'img-1': assetItem(imageAsset, {picked: false})
+          },
+          {lastPicked: 'anchor-9'}
+        )
+      }
+    })
+
+    setShiftPressed(true)
+    await user.click(clickFooterFilename('photo.png'))
+    setShiftPressed(false)
+
+    expect(store.getState().assets.byIds['img-1'].picked).toBe(true)
+    expect(store.getState().assets.byIds['anchor-9'].picked).toBe(true)
+  })
+
+  it('shows the selection checkmark when selected and not updating', () => {
+    const {container} = renderWithProviders(<CardAsset id="img-1" selected />, {
+      preloaded: {
+        assets: assetsState({'img-1': assetItem(imageAsset, {updating: false})})
+      }
+    })
+    expect(container.querySelectorAll('[data-sanity-icon="checkmark-circle"]').length).toBeGreaterThan(0)
+  })
+
+  it('does not show the checkmark overlay while updating even if selected', () => {
+    const {container} = renderWithProviders(<CardAsset id="img-1" selected />, {
+      preloaded: {
+        assets: assetsState({'img-1': assetItem(imageAsset, {updating: true})})
+      }
+    })
+    expect(container.querySelectorAll('[data-sanity-icon="checkmark-circle"]')).toHaveLength(0)
+  })
+
+  it('shows a spinner while updating', () => {
+    renderWithProviders(<CardAsset id="img-1" selected={false} />, {
+      preloaded: {
+        assets: assetsState({'img-1': assetItem(imageAsset, {updating: true})})
+      }
+    })
+    expect(document.body.querySelectorAll('[data-ui="Spinner"]').length).toBeGreaterThan(0)
+  })
+
+  it('shows a warning icon when the asset item has an error', () => {
+    const {container} = renderWithProviders(<CardAsset id="img-1" selected={false} />, {
+      preloaded: {
+        assets: assetsState({'img-1': assetItem(imageAsset, {error: 'Upload failed'})})
+      }
+    })
+    expect(container.querySelectorAll('[data-sanity-icon="warning-filled"]').length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/CardAsset/CardAsset.test.tsx
+++ b/src/components/CardAsset/CardAsset.test.tsx
@@ -24,7 +24,7 @@ vi.mock('../../hooks/useKeyPress', () => ({
       get current() {
         return Boolean((globalThis as unknown as Record<string, unknown>)[SHIFT_FLAG])
       }
-    }) as RefObject<boolean>
+    } as RefObject<boolean>)
 }))
 
 vi.mock('../Image', () => ({
@@ -159,9 +159,9 @@ describe('CardAsset', () => {
 
     await user.click(clickPreview())
 
-    expect(store.getState().dialog.items.some(d => d.type === 'assetEdit' && d.assetId === 'img-1')).toBe(
-      true
-    )
+    expect(
+      store.getState().dialog.items.some(d => d.type === 'assetEdit' && d.assetId === 'img-1')
+    ).toBe(true)
   })
 
   it('calls onSelect with the asset document id when the preview is clicked in picker mode', async () => {
@@ -210,9 +210,9 @@ describe('CardAsset', () => {
     await user.click(clickFooterFilename('photo.png'))
 
     expect(onSelect).not.toHaveBeenCalled()
-    expect(store.getState().dialog.items.some(d => d.type === 'assetEdit' && d.assetId === 'img-1')).toBe(
-      true
-    )
+    expect(
+      store.getState().dialog.items.some(d => d.type === 'assetEdit' && d.assetId === 'img-1')
+    ).toBe(true)
   })
 
   it('shift-clicks on preview to unpick when the asset is already picked', async () => {
@@ -255,7 +255,11 @@ describe('CardAsset', () => {
 
   it('shift-clicks on footer to pick a range when not picked', async () => {
     const user = userEvent.setup()
-    const anchorAsset = {...imageAsset, _id: 'anchor-9', originalFilename: 'anchor.png'} as ImageAsset
+    const anchorAsset = {
+      ...imageAsset,
+      _id: 'anchor-9',
+      originalFilename: 'anchor.png'
+    } as ImageAsset
     const {store} = renderWithProviders(<CardAsset id="img-1" selected={false} />, {
       preloaded: {
         assets: assetsState(
@@ -282,7 +286,9 @@ describe('CardAsset', () => {
         assets: assetsState({'img-1': assetItem(imageAsset, {updating: false})})
       }
     })
-    expect(container.querySelectorAll('[data-sanity-icon="checkmark-circle"]').length).toBeGreaterThan(0)
+    expect(
+      container.querySelectorAll('[data-sanity-icon="checkmark-circle"]').length
+    ).toBeGreaterThan(0)
   })
 
   it('does not show the checkmark overlay while updating even if selected', () => {
@@ -309,6 +315,8 @@ describe('CardAsset', () => {
         assets: assetsState({'img-1': assetItem(imageAsset, {error: 'Upload failed'})})
       }
     })
-    expect(container.querySelectorAll('[data-sanity-icon="warning-filled"]').length).toBeGreaterThan(0)
+    expect(
+      container.querySelectorAll('[data-sanity-icon="warning-filled"]').length
+    ).toBeGreaterThan(0)
   })
 })

--- a/src/components/DialogAssetEdit/DialogAssetEdit.test.tsx
+++ b/src/components/DialogAssetEdit/DialogAssetEdit.test.tsx
@@ -117,7 +117,14 @@ describe('DialogAssetEdit', () => {
     expect(store.getState().assets.byIds.a1.updating).toBe(true)
 
     await waitFor(() => {
-      const updateAction = dispatchSpy.mock.calls.map(([a]) => a).find(assetsActions.updateRequest.match)
+      let updateAction
+      for (const call of dispatchSpy.mock.calls) {
+        const action = call[0]
+        if (assetsActions.updateRequest.match(action)) {
+          updateAction = action
+          break
+        }
+      }
       expect(updateAction).toBeDefined()
       expect(updateAction?.payload).toMatchObject({
         asset,
@@ -175,7 +182,13 @@ describe('DialogAssetEdit', () => {
     fireEvent.click(dlg.getByRole('button', {name: /^delete$/i}))
 
     await waitFor(() => {
-      const confirm = store.getState().dialog.items.find(d => d.type === 'confirm')
+      let confirm
+      for (const d of store.getState().dialog.items) {
+        if (d.type === 'confirm') {
+          confirm = d
+          break
+        }
+      }
       expect(confirm).toBeDefined()
       expect(confirm?.title).toMatch(/permanently delete/i)
       expect(confirm?.headerTitle).toBe('Confirm deletion')

--- a/src/components/DialogAssetEdit/DialogAssetEdit.test.tsx
+++ b/src/components/DialogAssetEdit/DialogAssetEdit.test.tsx
@@ -1,0 +1,202 @@
+import userEvent from '@testing-library/user-event'
+import {fireEvent, screen, waitFor} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+import {Subject} from 'rxjs'
+import DialogAssetEdit from './index'
+
+vi.mock('../Image', () => ({default: () => null}))
+vi.mock('../FileAssetPreview', () => ({default: () => null}))
+vi.mock('../DocumentList', () => ({default: () => null}))
+vi.mock('../AssetMetadata', () => ({default: () => null}))
+import {createMockSanityClient} from '../../__tests__/fixtures/mockSanityClient'
+import {renderWithProviders} from '../../__tests__/fixtures/renderWithProviders'
+import {createTestRootState} from '../../__tests__/fixtures/rootState'
+import {inputByName, withinDialog} from '../../__tests__/fixtures/withinDialog'
+import type {RootReducerState} from '../../modules/types'
+import {assetsActions, initialState as assetsInitialState} from '../../modules/assets'
+import type {AssetType, ImageAsset, MediaToolOptions} from '../../types'
+
+const asset = {
+  _id: 'a1',
+  _type: 'sanity.imageAsset',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'r1',
+  originalFilename: 'x.png',
+  size: 1,
+  mimeType: 'image/png',
+  url: 'https://example.com/x.png',
+  metadata: {dimensions: {width: 100, height: 100}, isOpaque: true}
+} as ImageAsset
+
+const assetsPreloaded = {
+  ...assetsInitialState,
+  assetTypes: ['image'] as AssetType[],
+  allIds: ['a1'],
+  byIds: {
+    a1: {_type: 'asset' as const, asset, picked: false, updating: false}
+  }
+}
+
+vi.mock('sanity', async importOriginal => {
+  const actual = await importOriginal<typeof import('sanity')>()
+  return {
+    ...actual,
+    WithReferringDocuments: ({children}: {children: (args: unknown) => unknown}) =>
+      children({isLoading: false, referringDocuments: []}),
+    useDocumentStore: () => ({})
+  }
+})
+
+vi.mock('../../hooks/useVersionedClient', () => ({
+  default: () =>
+    createMockSanityClient({
+      listen: vi.fn(() => new Subject())
+    })
+}))
+
+function renderAssetDialog(
+  dialog: {id: string; type: 'assetEdit'; assetId: string},
+  opts: {
+    preloaded?: Partial<RootReducerState>
+    toolOptions?: Partial<MediaToolOptions>
+  } = {}
+) {
+  const {preloaded: extraPreloaded, toolOptions} = opts
+  return renderWithProviders(
+    <DialogAssetEdit dialog={dialog}>
+      <span />
+    </DialogAssetEdit>,
+    {
+      preloaded: {
+        assets: assetsPreloaded,
+        ...extraPreloaded
+      },
+      toolOptions: {creditLine: {enabled: true}, ...toolOptions}
+    }
+  )
+}
+
+describe('DialogAssetEdit', () => {
+  it('renders asset details header and details tab', () => {
+    renderAssetDialog({
+      id: 'dlg-1',
+      type: 'assetEdit',
+      assetId: 'a1'
+    })
+
+    const dlg = withinDialog(/asset details/i, screen)
+    expect(dlg.getByText('Asset details')).toBeInTheDocument()
+    expect(dlg.getByRole('tab', {name: 'Details'})).toBeInTheDocument()
+  })
+
+  it('keeps Save disabled until a field is edited', () => {
+    renderAssetDialog({
+      id: 'dlg-1',
+      type: 'assetEdit',
+      assetId: 'a1'
+    })
+
+    const dlg = withinDialog(/asset details/i, screen)
+    expect(dlg.getByRole('button', {name: /save and close/i})).toBeDisabled()
+  })
+
+  it('dispatches asset update when a field changes and the form is submitted', async () => {
+    const user = userEvent.setup()
+    const {store} = renderAssetDialog({
+      id: 'dlg-1',
+      type: 'assetEdit',
+      assetId: 'a1'
+    })
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+    const dlg = withinDialog(/asset details/i, screen)
+
+    await user.type(inputByName(/asset details/i, screen, 'title'), 'Hero image')
+    await user.click(dlg.getByRole('button', {name: /save and close/i}))
+
+    expect(store.getState().assets.byIds.a1.updating).toBe(true)
+
+    await waitFor(() => {
+      const updateAction = dispatchSpy.mock.calls.map(([a]) => a).find(assetsActions.updateRequest.match)
+      expect(updateAction).toBeDefined()
+      expect(updateAction?.payload).toMatchObject({
+        asset,
+        closeDialogId: 'a1',
+        formData: expect.objectContaining({
+          title: 'Hero image',
+          originalFilename: 'x.png'
+        })
+      })
+    })
+  })
+
+  it('removes only this dialog when closed', async () => {
+    const user = userEvent.setup()
+    const base = createTestRootState({
+      dialog: {
+        items: [
+          {id: 'dlg-1', type: 'assetEdit', assetId: 'a1'},
+          {id: 'tags', type: 'tags'}
+        ]
+      },
+      assets: assetsPreloaded
+    })
+
+    const {store} = renderWithProviders(
+      <DialogAssetEdit
+        dialog={{
+          id: 'dlg-1',
+          type: 'assetEdit',
+          assetId: 'a1'
+        }}
+      >
+        <span />
+      </DialogAssetEdit>,
+      {
+        preloaded: base,
+        toolOptions: {creditLine: {enabled: true}}
+      }
+    )
+
+    const dlg = withinDialog(/asset details/i, screen)
+    await user.click(dlg.getByRole('button', {name: /close dialog/i}))
+
+    expect(store.getState().dialog.items).toEqual([{id: 'tags', type: 'tags'}])
+  })
+
+  it('opens the delete confirmation dialog when Delete is clicked', async () => {
+    const {store} = renderAssetDialog({
+      id: 'dlg-1',
+      type: 'assetEdit',
+      assetId: 'a1'
+    })
+
+    const dlg = withinDialog(/asset details/i, screen)
+    fireEvent.click(dlg.getByRole('button', {name: /^delete$/i}))
+
+    await waitFor(() => {
+      const confirm = store.getState().dialog.items.find(d => d.type === 'confirm')
+      expect(confirm).toBeDefined()
+      expect(confirm?.title).toMatch(/permanently delete/i)
+      expect(confirm?.headerTitle).toBe('Confirm deletion')
+    })
+  })
+
+  it('switches to the References tab when that tab is activated', async () => {
+    const user = userEvent.setup()
+    renderAssetDialog({
+      id: 'dlg-1',
+      type: 'assetEdit',
+      assetId: 'a1'
+    })
+
+    const dlg = withinDialog(/asset details/i, screen)
+    const referencesTab = dlg.getByRole('tab', {name: /references/i})
+    expect(referencesTab).toHaveAttribute('aria-selected', 'false')
+
+    await user.click(referencesTab)
+
+    expect(referencesTab).toHaveAttribute('aria-selected', 'true')
+    expect(dlg.getByRole('tab', {name: 'Details'})).toHaveAttribute('aria-selected', 'false')
+  })
+})

--- a/src/components/DialogTagCreate/DialogTagCreate.test.tsx
+++ b/src/components/DialogTagCreate/DialogTagCreate.test.tsx
@@ -1,0 +1,113 @@
+import userEvent from '@testing-library/user-event'
+import {screen, waitFor} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+import DialogTagCreate from './index'
+import {renderWithProviders} from '../../__tests__/fixtures/renderWithProviders'
+import {createTestRootState} from '../../__tests__/fixtures/rootState'
+import {getDialogRoot, inputByName, withinDialog} from '../../__tests__/fixtures/withinDialog'
+import {tagsActions} from '../../modules/tags'
+
+describe('DialogTagCreate', () => {
+  it('dispatches tag create flow when form is valid', async () => {
+    const user = userEvent.setup()
+    const {store} = renderWithProviders(
+      <DialogTagCreate dialog={{id: 'dlg-1', type: 'tagCreate'}}>
+        <span />
+      </DialogTagCreate>
+    )
+
+    const dlg = withinDialog(/create tag/i, screen)
+    await user.type(inputByName(/create tag/i, screen, 'name'), 'my-tag')
+    await user.click(dlg.getByRole('button', {name: /save and close/i}))
+
+    expect(store.getState().tags.creating).toBe(true)
+  })
+
+  it('dispatches createRequest with a trimmed tag name', async () => {
+    const user = userEvent.setup()
+    const {store} = renderWithProviders(
+      <DialogTagCreate dialog={{id: 'dlg-1', type: 'tagCreate'}}>
+        <span />
+      </DialogTagCreate>
+    )
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+    const dlg = withinDialog(/create tag/i, screen)
+
+    await user.type(inputByName(/create tag/i, screen, 'name'), '  spaced  ')
+    await user.click(dlg.getByRole('button', {name: /save and close/i}))
+
+    await waitFor(() => {
+      const createAction = dispatchSpy.mock.calls.map(([a]) => a).find(tagsActions.createRequest.match)
+      expect(createAction).toBeDefined()
+      expect(createAction?.payload).toEqual({name: 'spaced'})
+    })
+  })
+
+  it('keeps Save disabled until the name is non-empty and valid', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <DialogTagCreate dialog={{id: 'dlg-1', type: 'tagCreate'}}>
+        <span />
+      </DialogTagCreate>
+    )
+
+    expect(
+      withinDialog(/create tag/i, screen).getByRole('button', {name: /save and close/i})
+    ).toBeDisabled()
+
+    const nameInput = inputByName(/create tag/i, screen, 'name')
+    await user.type(nameInput, 'a')
+    await user.tab()
+    await waitFor(() => {
+      expect(
+        withinDialog(/create tag/i, screen).getByRole('button', {name: /save and close/i})
+      ).not.toBeDisabled()
+    })
+  })
+
+  it('clears the entire dialog stack when the dialog close control is used', async () => {
+    const user = userEvent.setup()
+    const base = createTestRootState({
+      dialog: {
+        items: [
+          {id: 'dlg-1', type: 'tagCreate'},
+          {id: 'tags', type: 'tags'}
+        ]
+      }
+    })
+
+    const {store} = renderWithProviders(
+      <DialogTagCreate dialog={{id: 'dlg-1', type: 'tagCreate'}}>
+        <span />
+      </DialogTagCreate>,
+      {preloaded: base}
+    )
+
+    const dlg = withinDialog(/create tag/i, screen)
+    await user.click(dlg.getByRole('button', {name: /close dialog/i}))
+
+    expect(store.getState().dialog.items).toEqual([])
+  })
+
+  it('shows an error indicator beside the name when tag creation failed on the server', async () => {
+    const base = createTestRootState({
+      tags: {
+        ...createTestRootState().tags,
+        creatingError: {message: 'Tag already exists', statusCode: 409}
+      }
+    })
+
+    renderWithProviders(
+      <DialogTagCreate dialog={{id: 'dlg-1', type: 'tagCreate'}}>
+        <span />
+      </DialogTagCreate>,
+      {preloaded: base}
+    )
+
+    await waitFor(() => {
+      expect(
+        getDialogRoot(/create tag/i, screen).querySelector('[data-sanity-icon="error-outline"]')
+      ).toBeTruthy()
+    })
+  })
+})

--- a/src/components/DialogTagCreate/DialogTagCreate.test.tsx
+++ b/src/components/DialogTagCreate/DialogTagCreate.test.tsx
@@ -37,7 +37,14 @@ describe('DialogTagCreate', () => {
     await user.click(dlg.getByRole('button', {name: /save and close/i}))
 
     await waitFor(() => {
-      const createAction = dispatchSpy.mock.calls.map(([a]) => a).find(tagsActions.createRequest.match)
+      let createAction
+      for (const call of dispatchSpy.mock.calls) {
+        const action = call[0]
+        if (tagsActions.createRequest.match(action)) {
+          createAction = action
+          break
+        }
+      }
       expect(createAction).toBeDefined()
       expect(createAction?.payload).toEqual({name: 'spaced'})
     })

--- a/src/components/DialogTagEdit/DialogTagEdit.test.tsx
+++ b/src/components/DialogTagEdit/DialogTagEdit.test.tsx
@@ -81,9 +81,14 @@ describe('DialogTagEdit', () => {
     await user.click(dlg.getByRole('button', {name: /save and close/i}))
 
     await waitFor(() => {
-      const updateAction = dispatchSpy.mock.calls
-        .map(([a]) => a)
-        .find(tagsActions.updateRequest.match)
+      let updateAction
+      for (const call of dispatchSpy.mock.calls) {
+        const action = call[0]
+        if (tagsActions.updateRequest.match(action)) {
+          updateAction = action
+          break
+        }
+      }
       expect(updateAction).toBeDefined()
       expect(updateAction?.payload).toMatchObject({
         closeDialogId: 't1',

--- a/src/components/DialogTagEdit/DialogTagEdit.test.tsx
+++ b/src/components/DialogTagEdit/DialogTagEdit.test.tsx
@@ -1,0 +1,159 @@
+import userEvent from '@testing-library/user-event'
+import {fireEvent, screen, waitFor} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+import {Subject} from 'rxjs'
+import DialogTagEdit from './index'
+import {createMockSanityClient} from '../../__tests__/fixtures/mockSanityClient'
+import {renderWithProviders} from '../../__tests__/fixtures/renderWithProviders'
+import {createTestRootState} from '../../__tests__/fixtures/rootState'
+import {inputByName, withinDialog} from '../../__tests__/fixtures/withinDialog'
+import {tagsActions} from '../../modules/tags'
+import type {Tag} from '../../types'
+
+const tag: Tag = {
+  _id: 't1',
+  _type: 'media.tag',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'r1',
+  name: {_type: 'slug', current: 'alpha'}
+}
+
+const tagsPreloaded = {
+  allIds: ['t1'],
+  byIds: {
+    t1: {_type: 'tag' as const, tag, picked: false, updating: false}
+  },
+  creating: false,
+  fetchCount: -1,
+  fetching: false,
+  panelVisible: true
+}
+
+vi.mock('../../hooks/useVersionedClient', () => ({
+  default: () =>
+    createMockSanityClient({
+      listen: vi.fn(() => new Subject())
+    })
+}))
+
+describe('DialogTagEdit', () => {
+  it('dispatches updateRequest when name changes and form submits', async () => {
+    const user = userEvent.setup()
+    const {store} = renderWithProviders(
+      <DialogTagEdit dialog={{id: 'dlg-1', type: 'tagEdit', tagId: 't1'}}>
+        <span />
+      </DialogTagEdit>,
+      {
+        preloaded: {
+          tags: tagsPreloaded
+        }
+      }
+    )
+
+    const dlg = withinDialog(/edit tag/i, screen)
+    const input = inputByName(/edit tag/i, screen, 'name')
+    await user.clear(input)
+    await user.type(input, 'beta')
+    await user.click(dlg.getByRole('button', {name: /save and close/i}))
+
+    expect(store.getState().tags.byIds.t1.updating).toBe(true)
+  })
+
+  it('dispatches updateRequest with slug-shaped form data', async () => {
+    const user = userEvent.setup()
+    const {store} = renderWithProviders(
+      <DialogTagEdit dialog={{id: 'dlg-1', type: 'tagEdit', tagId: 't1'}}>
+        <span />
+      </DialogTagEdit>,
+      {
+        preloaded: {
+          tags: tagsPreloaded
+        }
+      }
+    )
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+    const dlg = withinDialog(/edit tag/i, screen)
+
+    const input = inputByName(/edit tag/i, screen, 'name')
+    await user.clear(input)
+    await user.type(input, 'gamma')
+    await user.click(dlg.getByRole('button', {name: /save and close/i}))
+
+    await waitFor(() => {
+      const updateAction = dispatchSpy.mock.calls
+        .map(([a]) => a)
+        .find(tagsActions.updateRequest.match)
+      expect(updateAction).toBeDefined()
+      expect(updateAction?.payload).toMatchObject({
+        closeDialogId: 't1',
+        formData: {
+          name: {_type: 'slug', current: 'gamma'}
+        },
+        tag
+      })
+    })
+  })
+
+  it('does not enable Save until the name is edited', () => {
+    renderWithProviders(
+      <DialogTagEdit dialog={{id: 'dlg-1', type: 'tagEdit', tagId: 't1'}}>
+        <span />
+      </DialogTagEdit>,
+      {
+        preloaded: {
+          tags: tagsPreloaded
+        }
+      }
+    )
+
+    const dlg = withinDialog(/edit tag/i, screen)
+    expect(dlg.getByRole('button', {name: /save and close/i})).toBeDisabled()
+  })
+
+  it('removes only this dialog when closed', async () => {
+    const user = userEvent.setup()
+    const base = createTestRootState({
+      dialog: {
+        items: [
+          {id: 'dlg-1', type: 'tagEdit', tagId: 't1'},
+          {id: 'tags', type: 'tags'}
+        ]
+      },
+      tags: tagsPreloaded
+    })
+
+    const {store} = renderWithProviders(
+      <DialogTagEdit dialog={{id: 'dlg-1', type: 'tagEdit', tagId: 't1'}}>
+        <span />
+      </DialogTagEdit>,
+      {preloaded: base}
+    )
+
+    const dlg = withinDialog(/edit tag/i, screen)
+    await user.click(dlg.getByRole('button', {name: /close dialog/i}))
+
+    expect(store.getState().dialog.items).toEqual([{id: 'tags', type: 'tags'}])
+  })
+
+  it('opens the delete confirmation dialog when Delete is clicked', async () => {
+    const {store} = renderWithProviders(
+      <DialogTagEdit dialog={{id: 'dlg-1', type: 'tagEdit', tagId: 't1'}}>
+        <span />
+      </DialogTagEdit>,
+      {
+        preloaded: {
+          tags: tagsPreloaded
+        }
+      }
+    )
+
+    const dlg = withinDialog(/edit tag/i, screen)
+    fireEvent.click(dlg.getByRole('button', {name: /^delete$/i}))
+
+    const confirm = store.getState().dialog.items.find(d => d.type === 'confirm')
+    expect(confirm).toBeDefined()
+    expect(confirm?.title).toMatch(/permanently delete/i)
+    expect(confirm?.headerTitle).toBe('Confirm deletion')
+  })
+})

--- a/src/components/FormBuilderTool/FormBuilderTool.test.tsx
+++ b/src/components/FormBuilderTool/FormBuilderTool.test.tsx
@@ -1,0 +1,62 @@
+import {describe, expect, it, vi, beforeEach} from 'vitest'
+import {render, screen, waitFor} from '@testing-library/react'
+import {LayerProvider, studioTheme, ThemeProvider, ToastProvider} from '@sanity/ui'
+import {ColorSchemeProvider} from 'sanity'
+import {of} from 'rxjs'
+import FormBuilderTool from './index'
+import {createListenMock} from '../../__tests__/fixtures/listenMock'
+import {createMockSanityClient} from '../../__tests__/fixtures/mockSanityClient'
+import {ToolOptionsProvider} from '../../contexts/ToolOptionsContext'
+import useVersionedClient from '../../hooks/useVersionedClient'
+
+vi.mock('../../hooks/useVersionedClient', () => ({
+  default: vi.fn()
+}))
+
+vi.mock('sanity', async importOriginal => {
+  const mod = await importOriginal<typeof import('sanity')>()
+  return {
+    ...mod,
+    useFormValue: () => ({_id: 'doc-1', _type: 'article'})
+  }
+})
+
+describe('FormBuilderTool', () => {
+  beforeEach(() => {
+    const fetch = vi.fn().mockReturnValue(of({items: []}))
+    vi.mocked(useVersionedClient).mockReturnValue(
+      createMockSanityClient({
+        listen: createListenMock(),
+        observable: {fetch}
+      })
+    )
+  })
+
+  it('renders picker header for image asset type', async () => {
+    render(
+      <ColorSchemeProvider scheme="light">
+        <ThemeProvider theme={studioTheme}>
+          <ToastProvider>
+            <LayerProvider>
+              <ToolOptionsProvider options={{creditLine: {enabled: false}}}>
+                <FormBuilderTool
+                  {...({
+                    assetType: 'image',
+                    onClose: vi.fn(),
+                    onSelect: vi.fn(),
+                    schemaType: {},
+                    selectedAssets: undefined
+                  } as any)}
+                />
+              </ToolOptionsProvider>
+            </LayerProvider>
+          </ToastProvider>
+        </ThemeProvider>
+      </ColorSchemeProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/Insert image/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/UploadDropzone/UploadDropzone.test.tsx
+++ b/src/components/UploadDropzone/UploadDropzone.test.tsx
@@ -1,0 +1,39 @@
+import {describe, expect, it} from 'vitest'
+import UploadDropzone from './index'
+import {renderWithProviders} from '../../__tests__/fixtures/renderWithProviders'
+import {initialState as assetsInitialState} from '../../modules/assets'
+
+describe('UploadDropzone', () => {
+  it('still renders file input when directUploads is false (dropzone in disabled mode)', () => {
+    const {container} = renderWithProviders(
+      <UploadDropzone>
+        <div />
+      </UploadDropzone>,
+      {
+        toolOptions: {creditLine: {enabled: false}, directUploads: false},
+        preloaded: {
+          assets: {...assetsInitialState, assetTypes: ['image', 'file']}
+        }
+      }
+    )
+
+    expect(container.querySelector('input[type="file"]')).toBeTruthy()
+  })
+
+  it('enables file input when directUploads is true', () => {
+    const {container} = renderWithProviders(
+      <UploadDropzone>
+        <div />
+      </UploadDropzone>,
+      {
+        toolOptions: {creditLine: {enabled: false}, directUploads: true},
+        preloaded: {
+          assets: {...assetsInitialState, assetTypes: ['image', 'file']}
+        }
+      }
+    )
+
+    const input = container.querySelector('input[type="file"]')
+    expect(input).not.toHaveAttribute('disabled')
+  })
+})

--- a/src/formSchema/index.test.ts
+++ b/src/formSchema/index.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+
+import {describe, expect, it} from 'vitest'
+import {assetFormSchema, tagFormSchema, tagOptionSchema} from './index'
+
+describe('tagOptionSchema', () => {
+  it('accepts trimmed non-empty label and value', () => {
+    expect(tagOptionSchema.safeParse({label: 'A', value: 'b'}).success).toBe(true)
+  })
+
+  it('rejects empty label or value after trim', () => {
+    expect(tagOptionSchema.safeParse({label: '  ', value: 'x'}).success).toBe(false)
+    expect(tagOptionSchema.safeParse({label: 'x', value: ''}).success).toBe(false)
+  })
+})
+
+describe('tagFormSchema', () => {
+  it('requires non-empty name', () => {
+    expect(tagFormSchema.safeParse({name: 'x'}).success).toBe(true)
+    expect(tagFormSchema.safeParse({name: ''}).success).toBe(false)
+  })
+})
+
+describe('assetFormSchema', () => {
+  const base = {
+    altText: '',
+    creditLine: '',
+    description: '',
+    opt: {media: {tags: null}},
+    originalFilename: 'file.png',
+    title: ''
+  }
+
+  it('accepts valid asset form payload', () => {
+    expect(assetFormSchema.safeParse(base).success).toBe(true)
+  })
+
+  it('rejects empty originalFilename', () => {
+    expect(
+      assetFormSchema.safeParse({
+        ...base,
+        originalFilename: '   '
+      }).success
+    ).toBe(false)
+  })
+
+  it('validates nested tag options', () => {
+    expect(
+      assetFormSchema.safeParse({
+        ...base,
+        opt: {media: {tags: [{label: '', value: 'v'}]}}
+      }).success
+    ).toBe(false)
+  })
+})

--- a/src/modules/assets/deleteAndUpdateEpics.test.ts
+++ b/src/modules/assets/deleteAndUpdateEpics.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment node
+
+import {describe, expect, it, vi} from 'vitest'
+import {of} from 'rxjs'
+import {
+  assetsActions,
+  assetsDeleteEpic,
+  assetsUpdateEpic,
+  initialState as assetsInitialState
+} from './index'
+import {createEpicTestStore} from '../../__tests__/fixtures/createEpicTestStore'
+import {createMockSanityClient, mockPatchChain} from '../../__tests__/fixtures/mockSanityClient'
+import type {ImageAsset} from '../../types'
+
+const sampleAsset = {
+  _id: 'a1',
+  _type: 'sanity.imageAsset',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'r',
+  originalFilename: 'x.png',
+  size: 1,
+  mimeType: 'image/png',
+  url: ''
+} as ImageAsset
+
+describe('assetsDeleteEpic', () => {
+  it('dispatches deleteComplete when observable.delete succeeds', async () => {
+    const client = createMockSanityClient({
+      observable: {
+        delete: vi.fn(() => of({}))
+      }
+    })
+
+    const store = createEpicTestStore(assetsDeleteEpic, client, {
+      assets: {
+        ...assetsInitialState,
+        assetTypes: ['image'],
+        allIds: ['a1'],
+        byIds: {
+          a1: {_type: 'asset', asset: sampleAsset, picked: false, updating: false}
+        }
+      }
+    })
+
+    store.dispatch(assetsActions.deleteRequest({assets: [sampleAsset]}))
+
+    await vi.waitFor(() => {
+      expect(store.getState().assets.byIds.a1).toBeUndefined()
+      expect(client.observable.delete).toHaveBeenCalled()
+    })
+  })
+})
+
+describe('assetsUpdateEpic', () => {
+  it('commits patch and dispatches updateComplete', async () => {
+    const updated = {...sampleAsset, title: 'Updated'}
+    const chain = mockPatchChain(updated)
+    const client = createMockSanityClient({
+      patch: vi.fn(() => chain)
+    })
+
+    const store = createEpicTestStore(assetsUpdateEpic, client, {
+      assets: {
+        ...assetsInitialState,
+        assetTypes: ['image'],
+        allIds: ['a1'],
+        byIds: {
+          a1: {_type: 'asset', asset: sampleAsset, picked: false, updating: false}
+        }
+      }
+    })
+
+    store.dispatch(
+      assetsActions.updateRequest({
+        asset: sampleAsset,
+        formData: {title: 'Updated'}
+      })
+    )
+
+    await vi.waitFor(() => {
+      expect(chain.commit).toHaveBeenCalled()
+      expect(store.getState().assets.byIds.a1.asset.title).toBe('Updated')
+    })
+  })
+})

--- a/src/modules/assets/fetchEpic.test.ts
+++ b/src/modules/assets/fetchEpic.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+
+import {describe, expect, it, vi} from 'vitest'
+import {of, throwError} from 'rxjs'
+import {assetsActions, assetsFetchEpic} from './index'
+import {createEpicTestStore} from '../../__tests__/fixtures/createEpicTestStore'
+import {createMockSanityClient} from '../../__tests__/fixtures/mockSanityClient'
+import type {ImageAsset} from '../../types'
+
+function assertFetchSucceeded(store: ReturnType<typeof createEpicTestStore>, asset: ImageAsset) {
+  expect(store.getState().assets.byIds.a1?.asset).toEqual(asset)
+  expect(store.getState().assets.fetching).toBe(false)
+}
+
+function assertFetchFailed(store: ReturnType<typeof createEpicTestStore>) {
+  expect(store.getState().assets.fetchingError?.message).toBe('boom')
+}
+
+const sampleAsset = {
+  _id: 'a1',
+  _type: 'sanity.imageAsset',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'r',
+  originalFilename: 'x.png',
+  size: 1,
+  mimeType: 'image/png',
+  url: ''
+} as ImageAsset
+
+describe('assetsFetchEpic', () => {
+  it('dispatches fetchComplete when observable.fetch succeeds', async () => {
+    const client = createMockSanityClient({
+      observable: {
+        fetch: vi.fn(() => of({items: [sampleAsset]}))
+      }
+    })
+
+    const store = createEpicTestStore(assetsFetchEpic, client)
+    store.dispatch(
+      assetsActions.fetchRequest({
+        params: {},
+        queryFilter: '_type == "sanity.imageAsset"',
+        selector: '',
+        sort: ''
+      })
+    )
+
+    await vi.waitFor(() => assertFetchSucceeded(store, sampleAsset))
+  })
+
+  it('dispatches fetchError when fetch fails', async () => {
+    const fetchErr = throwError(() => ({message: 'boom', statusCode: 500}))
+    const client = createMockSanityClient({
+      observable: {
+        fetch: vi.fn(() => fetchErr)
+      }
+    })
+
+    const store = createEpicTestStore(assetsFetchEpic, client)
+    store.dispatch(
+      assetsActions.fetchRequest({
+        params: {},
+        queryFilter: '_type == "sanity.imageAsset"',
+        selector: '',
+        sort: ''
+      })
+    )
+
+    await vi.waitFor(() => assertFetchFailed(store))
+  })
+})

--- a/src/modules/assets/reducer.test.ts
+++ b/src/modules/assets/reducer.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+
+import {describe, expect, it} from 'vitest'
+import type {AssetType, ImageAsset} from '../../types'
+import assetsReducer, {assetsActions, initialState, type AssetsReducerState} from './index'
+
+const minimalImage = {
+  _id: 'img-1',
+  _type: 'sanity.imageAsset',
+  _createdAt: '2020-01-01',
+  _updatedAt: '2020-01-01',
+  _rev: 'r1',
+  originalFilename: 'a.png',
+  size: 1,
+  mimeType: 'image/png',
+  url: 'https://example.com/a.png'
+} as ImageAsset
+
+describe('assets slice', () => {
+  function stateWithOneAsset(): AssetsReducerState {
+    return {
+      ...initialState,
+      assetTypes: ['image'] as AssetType[],
+      allIds: ['img-1'],
+      byIds: {
+        'img-1': {
+          _type: 'asset',
+          asset: minimalImage,
+          picked: false,
+          updating: false
+        }
+      }
+    }
+  }
+
+  it('pick toggles picked flag', () => {
+    let state = stateWithOneAsset()
+    state = assetsReducer(state, assetsActions.pick({assetId: 'img-1', picked: true}))
+    expect(state.byIds['img-1'].picked).toBe(true)
+    expect(state.lastPicked).toBe('img-1')
+  })
+
+  it('pickClear clears selection', () => {
+    let state = stateWithOneAsset()
+    state = assetsReducer(state, assetsActions.pick({assetId: 'img-1', picked: true}))
+    state = assetsReducer(state, assetsActions.pickClear())
+    expect(state.byIds['img-1'].picked).toBe(false)
+    expect(state.lastPicked).toBeUndefined()
+  })
+
+  it('fetchComplete merges assets', () => {
+    let state = assetsReducer(
+      {...initialState, assetTypes: ['image'] as AssetType[]},
+      {type: '@@INIT'} as never
+    )
+    state = assetsReducer(state, assetsActions.fetchComplete({assets: [minimalImage]}))
+    expect(state.allIds).toContain('img-1')
+    expect(state.fetching).toBe(false)
+    expect(state.fetchCount).toBe(1)
+  })
+
+  it('orderSet resets page index', () => {
+    let state: AssetsReducerState = {
+      ...initialState,
+      assetTypes: ['image'] as AssetType[],
+      pageIndex: 3
+    }
+    state = assetsReducer(
+      state,
+      assetsActions.orderSet({
+        order: {field: 'size', direction: 'asc'}
+      })
+    )
+    expect(state.pageIndex).toBe(0)
+    expect(state.order.field).toBe('size')
+  })
+
+  it('listenerDeleteQueueComplete removes assets', () => {
+    let state = stateWithOneAsset()
+    state = assetsReducer(state, assetsActions.listenerDeleteQueueComplete({assetIds: ['img-1']}))
+    expect(state.allIds).toHaveLength(0)
+    expect(state.byIds['img-1']).toBeUndefined()
+  })
+
+  it('listenerUpdateQueueComplete updates asset document', () => {
+    let state = stateWithOneAsset()
+    const updated = {...minimalImage, title: 'New'}
+    state = assetsReducer(state, assetsActions.listenerUpdateQueueComplete({assets: [updated]}))
+    expect(state.byIds['img-1'].asset.title).toBe('New')
+  })
+})

--- a/src/modules/assets/reducer.test.ts
+++ b/src/modules/assets/reducer.test.ts
@@ -49,10 +49,9 @@ describe('assets slice', () => {
   })
 
   it('fetchComplete merges assets', () => {
-    let state = assetsReducer(
-      {...initialState, assetTypes: ['image'] as AssetType[]},
-      {type: '@@INIT'} as never
-    )
+    let state = assetsReducer({...initialState, assetTypes: ['image'] as AssetType[]}, {
+      type: '@@INIT'
+    } as never)
     state = assetsReducer(state, assetsActions.fetchComplete({assets: [minimalImage]}))
     expect(state.allIds).toContain('img-1')
     expect(state.fetching).toBe(false)

--- a/src/modules/assets/tagsAndListenerEpics.test.ts
+++ b/src/modules/assets/tagsAndListenerEpics.test.ts
@@ -1,0 +1,205 @@
+// @vitest-environment node
+
+import {describe, expect, it, vi, beforeEach, afterEach} from 'vitest'
+import {
+  assetsActions,
+  assetsListenerCreateQueueEpic,
+  assetsListenerDeleteQueueEpic,
+  assetsListenerUpdateQueueEpic,
+  assetsTagsAddEpic,
+  assetsTagsRemoveEpic
+} from './index'
+import {ASSETS_ACTIONS} from './actions'
+import {createEpicTestStore} from '../../__tests__/fixtures/createEpicTestStore'
+import {
+  createMockSanityClient,
+  mockTransactionCommit
+} from '../../__tests__/fixtures/mockSanityClient'
+import {initialState as assetsInitialState} from './index'
+import type {ImageAsset, Tag} from '../../types'
+
+const sampleAsset = {
+  _id: 'a1',
+  _type: 'sanity.imageAsset',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'r1',
+  originalFilename: 'x.png',
+  size: 1,
+  mimeType: 'image/png',
+  url: ''
+} as ImageAsset
+
+const sampleTag: Tag = {
+  _id: 't1',
+  _type: 'media.tag',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'tr',
+  name: {_type: 'slug', current: 'tag-a'}
+}
+
+describe('assetsTagsAddEpic', () => {
+  it('runs transaction.commit when adding tag to picked assets', async () => {
+    const tx = mockTransactionCommit(undefined)
+    const client = createMockSanityClient({
+      transaction: vi.fn(() => tx)
+    })
+
+    const assetItem = {
+      _type: 'asset' as const,
+      asset: sampleAsset,
+      picked: true,
+      updating: false
+    }
+
+    const store = createEpicTestStore(assetsTagsAddEpic, client, {
+      assets: {
+        ...assetsInitialState,
+        assetTypes: ['image'],
+        allIds: ['a1'],
+        byIds: {a1: assetItem}
+      },
+      tags: {
+        allIds: ['t1'],
+        byIds: {
+          t1: {_type: 'tag', tag: sampleTag, picked: false, updating: false}
+        },
+        creating: false,
+        fetchCount: -1,
+        fetching: false,
+        panelVisible: true
+      }
+    })
+
+    store.dispatch(
+      ASSETS_ACTIONS.tagsAddRequest({
+        assets: [assetItem],
+        tag: sampleTag
+      })
+    )
+
+    await vi.waitFor(() => {
+      expect(tx.commit).toHaveBeenCalled()
+    })
+  })
+})
+
+describe('assetsTagsRemoveEpic', () => {
+  it('runs transaction.commit for tag removal', async () => {
+    const tx = mockTransactionCommit(undefined)
+    const client = createMockSanityClient({
+      transaction: vi.fn(() => tx)
+    })
+
+    const assetItem = {
+      _type: 'asset' as const,
+      asset: sampleAsset,
+      picked: true,
+      updating: false
+    }
+
+    const store = createEpicTestStore(assetsTagsRemoveEpic, client, {
+      assets: {
+        ...assetsInitialState,
+        assetTypes: ['image'],
+        allIds: ['a1'],
+        byIds: {a1: assetItem}
+      },
+      tags: {
+        allIds: ['t1'],
+        byIds: {
+          t1: {_type: 'tag', tag: sampleTag, picked: false, updating: false}
+        },
+        creating: false,
+        fetchCount: -1,
+        fetching: false,
+        panelVisible: true
+      }
+    })
+
+    store.dispatch(
+      ASSETS_ACTIONS.tagsRemoveRequest({
+        assets: [assetItem],
+        tag: sampleTag
+      })
+    )
+
+    await vi.waitFor(() => {
+      expect(tx.commit).toHaveBeenCalled()
+    })
+  })
+})
+
+describe('assets listener queue epics', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('assetsListenerCreateQueueEpic batches creates after buffer window', async () => {
+    const store = createEpicTestStore(assetsListenerCreateQueueEpic, createMockSanityClient(), {
+      assets: {
+        ...assetsInitialState,
+        assetTypes: ['image'],
+        allIds: ['a1'],
+        byIds: {
+          a1: {_type: 'asset', asset: sampleAsset, picked: false, updating: false}
+        }
+      }
+    })
+
+    const updated = {...sampleAsset, title: 'L'}
+    store.dispatch(assetsActions.listenerCreateQueue({asset: updated}))
+
+    await vi.advanceTimersByTimeAsync(2000)
+
+    await vi.waitFor(() => {
+      expect(store.getState().assets.byIds.a1.asset.title).toBe('L')
+    })
+  })
+
+  it('assetsListenerDeleteQueueEpic batches deletes', async () => {
+    const store = createEpicTestStore(assetsListenerDeleteQueueEpic, createMockSanityClient(), {
+      assets: {
+        ...assetsInitialState,
+        assetTypes: ['image'],
+        allIds: ['a1'],
+        byIds: {
+          a1: {_type: 'asset', asset: sampleAsset, picked: false, updating: false}
+        }
+      }
+    })
+
+    store.dispatch(assetsActions.listenerDeleteQueue({assetId: 'a1'}))
+    await vi.advanceTimersByTimeAsync(2000)
+
+    await vi.waitFor(() => {
+      expect(store.getState().assets.byIds.a1).toBeUndefined()
+    })
+  })
+
+  it('assetsListenerUpdateQueueEpic batches updates', async () => {
+    const store = createEpicTestStore(assetsListenerUpdateQueueEpic, createMockSanityClient(), {
+      assets: {
+        ...assetsInitialState,
+        assetTypes: ['image'],
+        allIds: ['a1'],
+        byIds: {
+          a1: {_type: 'asset', asset: sampleAsset, picked: false, updating: false}
+        }
+      }
+    })
+
+    const updated = {...sampleAsset, title: 'Buffered'}
+    store.dispatch(assetsActions.listenerUpdateQueue({asset: updated}))
+    await vi.advanceTimersByTimeAsync(2000)
+
+    await vi.waitFor(() => {
+      expect(store.getState().assets.byIds.a1.asset.title).toBe('Buffered')
+    })
+  })
+})

--- a/src/modules/dialog/epics.test.ts
+++ b/src/modules/dialog/epics.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment node
+
+import {describe, expect, it, vi} from 'vitest'
+import {dialogClearOnAssetUpdateEpic, dialogTagCreateEpic, dialogTagDeleteEpic} from './index'
+import {assetsActions, initialState as assetsInitialState} from '../assets'
+import {tagsActions} from '../tags'
+import {createEpicTestStore} from '../../__tests__/fixtures/createEpicTestStore'
+import {createMockSanityClient} from '../../__tests__/fixtures/mockSanityClient'
+import type {ImageAsset, Tag} from '../../types'
+
+const sampleAsset = {
+  _id: 'a1',
+  _type: 'sanity.imageAsset',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'r1',
+  originalFilename: 'x.png',
+  size: 1,
+  mimeType: 'image/png',
+  url: 'https://example.com/x.png'
+} as ImageAsset
+
+const sampleTag: Tag = {
+  _id: 't1',
+  _type: 'media.tag',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'tr',
+  name: {_type: 'slug', current: 'alpha'}
+}
+
+const tagWithId = (id: string): Tag => ({
+  ...sampleTag,
+  _id: id
+})
+
+describe('dialogClearOnAssetUpdateEpic', () => {
+  it('removes the dialog when assets.updateComplete carries closeDialogId', async () => {
+    const store = createEpicTestStore(dialogClearOnAssetUpdateEpic, createMockSanityClient({}), {
+      assets: {
+        ...assetsInitialState,
+        assetTypes: ['image'],
+        allIds: ['a1'],
+        byIds: {
+          a1: {_type: 'asset', asset: sampleAsset, picked: false, updating: true}
+        }
+      },
+      dialog: {
+        items: [{id: 'a1', type: 'assetEdit', assetId: 'a1'}]
+      }
+    })
+
+    store.dispatch(assetsActions.updateComplete({asset: sampleAsset, closeDialogId: 'a1'}))
+
+    await vi.waitFor(() => {
+      expect(store.getState().dialog.items).toHaveLength(0)
+    })
+  })
+
+  it('removes the dialog when tags.updateComplete carries closeDialogId', async () => {
+    const store = createEpicTestStore(dialogClearOnAssetUpdateEpic, createMockSanityClient({}), {
+      tags: {
+        allIds: ['t1'],
+        byIds: {
+          t1: {_type: 'tag', tag: sampleTag, picked: false, updating: true}
+        },
+        creating: false,
+        fetchCount: -1,
+        fetching: false,
+        panelVisible: true
+      },
+      dialog: {
+        items: [{id: 't1', type: 'tagEdit', tagId: 't1'}]
+      }
+    })
+
+    store.dispatch(tagsActions.updateComplete({tag: sampleTag, closeDialogId: 't1'}))
+
+    await vi.waitFor(() => {
+      expect(store.getState().dialog.items).toHaveLength(0)
+    })
+  })
+
+  it('does not emit remove when closeDialogId is absent', async () => {
+    const store = createEpicTestStore(dialogClearOnAssetUpdateEpic, createMockSanityClient({}), {
+      assets: {
+        ...assetsInitialState,
+        assetTypes: ['image'],
+        allIds: ['a1'],
+        byIds: {
+          a1: {_type: 'asset', asset: sampleAsset, picked: false, updating: true}
+        }
+      },
+      dialog: {
+        items: [{id: 'a1', type: 'assetEdit', assetId: 'a1'}]
+      }
+    })
+
+    store.dispatch(assetsActions.updateComplete({asset: sampleAsset}))
+
+    expect(store.getState().dialog.items).toHaveLength(1)
+  })
+})
+
+describe('dialogTagCreateEpic', () => {
+  it('dispatches inlineTagCreate when createComplete includes assetId', async () => {
+    const store = createEpicTestStore(dialogTagCreateEpic, createMockSanityClient({}), {
+      dialog: {
+        items: [{id: 'a1', type: 'assetEdit', assetId: 'a1'}]
+      }
+    })
+
+    store.dispatch(tagsActions.createComplete({assetId: 'a1', tag: sampleTag}))
+
+    await vi.waitFor(() => {
+      const item = store.getState().dialog.items[0]
+      expect(item?.type).toBe('assetEdit')
+      expect('lastCreatedTag' in item && item.lastCreatedTag).toEqual({
+        label: 'alpha',
+        value: 't1'
+      })
+    })
+  })
+
+  it('removes tag create dialog when createComplete has no assetId', async () => {
+    const store = createEpicTestStore(dialogTagCreateEpic, createMockSanityClient({}), {
+      dialog: {
+        items: [{id: 'tagCreate', type: 'tagCreate'}]
+      }
+    })
+
+    store.dispatch(tagsActions.createComplete({tag: sampleTag}))
+
+    await vi.waitFor(() => {
+      expect(store.getState().dialog.items).toHaveLength(0)
+    })
+  })
+})
+
+describe('dialogTagDeleteEpic', () => {
+  it('dispatches inlineTagRemove with listener tag ids', async () => {
+    const store = createEpicTestStore(dialogTagDeleteEpic, createMockSanityClient({}), {
+      tags: {
+        allIds: ['t9'],
+        byIds: {
+          t9: {_type: 'tag', tag: tagWithId('t9'), picked: false, updating: false}
+        },
+        creating: false,
+        fetchCount: -1,
+        fetching: false,
+        panelVisible: true
+      },
+      dialog: {
+        items: [{id: 'a1', type: 'assetEdit', assetId: 'a1'}]
+      }
+    })
+
+    store.dispatch(tagsActions.listenerDeleteQueueComplete({tagIds: ['t9']}))
+
+    await vi.waitFor(() => {
+      expect(store.getState().dialog.items[0]).toMatchObject({
+        type: 'assetEdit',
+        lastRemovedTagIds: ['t9']
+      })
+    })
+  })
+})

--- a/src/modules/dialog/reducer.test.ts
+++ b/src/modules/dialog/reducer.test.ts
@@ -1,0 +1,184 @@
+// @vitest-environment node
+
+import {describe, expect, it} from 'vitest'
+import {DIALOG_ACTIONS} from './actions'
+import dialogReducer, {dialogActions} from './index'
+import {assetsActions} from '../assets'
+import {ASSETS_ACTIONS} from '../assets/actions'
+import {tagsActions} from '../tags'
+import type {AssetItem, ImageAsset, Tag} from '../../types'
+import {createTestRootState} from '../../__tests__/fixtures/rootState'
+
+const sampleAsset = {
+  _id: 'a1',
+  _type: 'sanity.imageAsset',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'r1',
+  originalFilename: 'x.png',
+  size: 1,
+  mimeType: 'image/png',
+  url: 'https://example.com/x.png'
+} as ImageAsset
+
+const sampleTag: Tag = {
+  _id: 't1',
+  _type: 'media.tag',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'tr',
+  name: {_type: 'slug', current: 'alpha'}
+}
+
+const assetItem = (asset: ImageAsset = sampleAsset): AssetItem => ({
+  _type: 'asset',
+  asset,
+  picked: false,
+  updating: false
+})
+
+function dialogState() {
+  return createTestRootState().dialog
+}
+
+describe('dialog slice reducers', () => {
+  it('clear removes all items', () => {
+    let state = dialogReducer(
+      {...dialogState(), items: [{id: 'x', type: 'tags'}]},
+      dialogActions.clear()
+    )
+    expect(state.items).toEqual([])
+  })
+
+  it('remove filters out the dialog with the given id', () => {
+    let state = dialogReducer(
+      {
+        ...dialogState(),
+        items: [
+          {id: 'a', type: 'tags'},
+          {id: 'b', type: 'searchFacets'}
+        ]
+      },
+      dialogActions.remove({id: 'a'})
+    )
+    expect(state.items).toEqual([{id: 'b', type: 'searchFacets'}])
+  })
+
+  it('showAssetEdit appends an asset edit dialog', () => {
+    let state = dialogReducer(dialogState(), dialogActions.showAssetEdit({assetId: 'a1'}))
+    expect(state.items).toEqual([{assetId: 'a1', id: 'a1', type: 'assetEdit'}])
+  })
+
+  it('showSearchFacets and showTags append the expected dialogs', () => {
+    let state = dialogReducer(dialogState(), dialogActions.showSearchFacets())
+    state = dialogReducer(state, dialogActions.showTags())
+    expect(state.items).toEqual([
+      {id: 'searchFacets', type: 'searchFacets'},
+      {id: 'tags', type: 'tags'}
+    ])
+  })
+
+  it('inlineTagCreate sets lastCreatedTag on matching assetEdit items', () => {
+    let state = dialogReducer(
+      {
+        ...dialogState(),
+        items: [
+          {id: 'a1', type: 'assetEdit', assetId: 'a1'},
+          {id: 'a2', type: 'assetEdit', assetId: 'a2'}
+        ]
+      },
+      dialogActions.inlineTagCreate({assetId: 'a1', tag: sampleTag})
+    )
+    const a1 = state.items.find(i => i.type === 'assetEdit' && i.assetId === 'a1')
+    const a2 = state.items.find(i => i.type === 'assetEdit' && i.assetId === 'a2')
+    expect(a1 && 'lastCreatedTag' in a1 && a1.lastCreatedTag).toEqual({
+      label: 'alpha',
+      value: 't1'
+    })
+    expect(a2).toBeDefined()
+    expect(Object.prototype.hasOwnProperty.call(a2, 'lastCreatedTag')).toBe(false)
+  })
+
+  it('inlineTagRemove sets lastRemovedTagIds on all assetEdit items', () => {
+    let state = dialogReducer(
+      {
+        ...dialogState(),
+        items: [
+          {id: 'a1', type: 'assetEdit', assetId: 'a1'},
+          {id: 'tags', type: 'tags'}
+        ]
+      },
+      dialogActions.inlineTagRemove({tagIds: ['x', 'y']})
+    )
+    const edit = state.items.find(i => i.type === 'assetEdit')
+    expect(edit && 'lastRemovedTagIds' in edit && edit.lastRemovedTagIds).toEqual(['x', 'y'])
+    const tagsPanel = state.items.find(i => i.type === 'tags')
+    expect(tagsPanel && 'lastRemovedTagIds' in tagsPanel).toBeFalsy()
+  })
+
+  it('showConfirmDeleteAssets pushes a confirm dialog wired to assets deleteRequest', () => {
+    const item = assetItem()
+    let state = dialogReducer(
+      dialogState(),
+      dialogActions.showConfirmDeleteAssets({assets: [item], closeDialogId: 'a1'})
+    )
+    const confirm = state.items[0]
+    expect(confirm?.type).toBe('confirm')
+    expect(confirm && 'title' in confirm && confirm.title).toBe('Permanently delete 1 asset?')
+    const cb = confirm && 'confirmCallbackAction' in confirm ? confirm.confirmCallbackAction : null
+    expect(cb).toEqual(assetsActions.deleteRequest({assets: [sampleAsset]}))
+  })
+
+  it('showConfirmDeleteTag pushes a confirm dialog wired to tags deleteRequest', () => {
+    let state = dialogReducer(
+      dialogState(),
+      dialogActions.showConfirmDeleteTag({closeDialogId: 't1', tag: sampleTag})
+    )
+    const confirm = state.items[0]
+    expect(confirm?.type).toBe('confirm')
+    expect(confirm && 'title' in confirm && confirm.title).toMatch(/permanently delete/i)
+    const cb = confirm && 'confirmCallbackAction' in confirm ? confirm.confirmCallbackAction : null
+    expect(cb).toEqual(tagsActions.deleteRequest({tag: sampleTag}))
+  })
+
+  it('showConfirmAssetsTagAdd uses plural copy for multiple assets', () => {
+    const a2 = {...sampleAsset, _id: 'a2', originalFilename: 'y.png'} as ImageAsset
+    let state = dialogReducer(
+      dialogState(),
+      dialogActions.showConfirmAssetsTagAdd({
+        assetsPicked: [assetItem(), assetItem(a2)],
+        tag: sampleTag
+      })
+    )
+    const confirm = state.items[0]
+    expect(confirm && 'title' in confirm && confirm.title).toContain('2 assets')
+    const cb = confirm && 'confirmCallbackAction' in confirm ? confirm.confirmCallbackAction : null
+    expect(cb).toEqual(
+      ASSETS_ACTIONS.tagsAddRequest({assets: [assetItem(), assetItem(a2)], tag: sampleTag})
+    )
+  })
+
+  it('showConfirmAssetsTagRemove pushes removal confirm with tagsRemoveRequest', () => {
+    let state = dialogReducer(
+      dialogState(),
+      dialogActions.showConfirmAssetsTagRemove({
+        assetsPicked: [assetItem()],
+        tag: sampleTag
+      })
+    )
+    const confirm = state.items[0]
+    expect(confirm && 'tone' in confirm && confirm.tone).toBe('critical')
+    const cb = confirm && 'confirmCallbackAction' in confirm ? confirm.confirmCallbackAction : null
+    expect(cb).toEqual(ASSETS_ACTIONS.tagsRemoveRequest({assets: [assetItem()], tag: sampleTag}))
+  })
+
+  it('DIALOG_ACTIONS.showTagCreate appends tag create dialog', () => {
+    let state = dialogReducer(dialogState(), DIALOG_ACTIONS.showTagCreate())
+    expect(state.items).toEqual([{id: 'tagCreate', type: 'tagCreate'}])
+  })
+
+  it('DIALOG_ACTIONS.showTagEdit appends tag edit dialog with tag id', () => {
+    let state = dialogReducer(dialogState(), DIALOG_ACTIONS.showTagEdit({tagId: 't9'}))
+    expect(state.items).toEqual([{id: 't9', tagId: 't9', type: 'tagEdit'}])
+  })
+})

--- a/src/modules/dialog/reducer.test.ts
+++ b/src/modules/dialog/reducer.test.ts
@@ -43,7 +43,7 @@ function dialogState() {
 
 describe('dialog slice reducers', () => {
   it('clear removes all items', () => {
-    let state = dialogReducer(
+    const state = dialogReducer(
       {...dialogState(), items: [{id: 'x', type: 'tags'}]},
       dialogActions.clear()
     )
@@ -51,7 +51,7 @@ describe('dialog slice reducers', () => {
   })
 
   it('remove filters out the dialog with the given id', () => {
-    let state = dialogReducer(
+    const state = dialogReducer(
       {
         ...dialogState(),
         items: [
@@ -65,7 +65,7 @@ describe('dialog slice reducers', () => {
   })
 
   it('showAssetEdit appends an asset edit dialog', () => {
-    let state = dialogReducer(dialogState(), dialogActions.showAssetEdit({assetId: 'a1'}))
+    const state = dialogReducer(dialogState(), dialogActions.showAssetEdit({assetId: 'a1'}))
     expect(state.items).toEqual([{assetId: 'a1', id: 'a1', type: 'assetEdit'}])
   })
 
@@ -79,7 +79,7 @@ describe('dialog slice reducers', () => {
   })
 
   it('inlineTagCreate sets lastCreatedTag on matching assetEdit items', () => {
-    let state = dialogReducer(
+    const state = dialogReducer(
       {
         ...dialogState(),
         items: [
@@ -100,7 +100,7 @@ describe('dialog slice reducers', () => {
   })
 
   it('inlineTagRemove sets lastRemovedTagIds on all assetEdit items', () => {
-    let state = dialogReducer(
+    const state = dialogReducer(
       {
         ...dialogState(),
         items: [
@@ -118,7 +118,7 @@ describe('dialog slice reducers', () => {
 
   it('showConfirmDeleteAssets pushes a confirm dialog wired to assets deleteRequest', () => {
     const item = assetItem()
-    let state = dialogReducer(
+    const state = dialogReducer(
       dialogState(),
       dialogActions.showConfirmDeleteAssets({assets: [item], closeDialogId: 'a1'})
     )
@@ -130,7 +130,7 @@ describe('dialog slice reducers', () => {
   })
 
   it('showConfirmDeleteTag pushes a confirm dialog wired to tags deleteRequest', () => {
-    let state = dialogReducer(
+    const state = dialogReducer(
       dialogState(),
       dialogActions.showConfirmDeleteTag({closeDialogId: 't1', tag: sampleTag})
     )
@@ -143,7 +143,7 @@ describe('dialog slice reducers', () => {
 
   it('showConfirmAssetsTagAdd uses plural copy for multiple assets', () => {
     const a2 = {...sampleAsset, _id: 'a2', originalFilename: 'y.png'} as ImageAsset
-    let state = dialogReducer(
+    const state = dialogReducer(
       dialogState(),
       dialogActions.showConfirmAssetsTagAdd({
         assetsPicked: [assetItem(), assetItem(a2)],
@@ -159,7 +159,7 @@ describe('dialog slice reducers', () => {
   })
 
   it('showConfirmAssetsTagRemove pushes removal confirm with tagsRemoveRequest', () => {
-    let state = dialogReducer(
+    const state = dialogReducer(
       dialogState(),
       dialogActions.showConfirmAssetsTagRemove({
         assetsPicked: [assetItem()],
@@ -173,12 +173,12 @@ describe('dialog slice reducers', () => {
   })
 
   it('DIALOG_ACTIONS.showTagCreate appends tag create dialog', () => {
-    let state = dialogReducer(dialogState(), DIALOG_ACTIONS.showTagCreate())
+    const state = dialogReducer(dialogState(), DIALOG_ACTIONS.showTagCreate())
     expect(state.items).toEqual([{id: 'tagCreate', type: 'tagCreate'}])
   })
 
   it('DIALOG_ACTIONS.showTagEdit appends tag edit dialog with tag id', () => {
-    let state = dialogReducer(dialogState(), DIALOG_ACTIONS.showTagEdit({tagId: 't9'}))
+    const state = dialogReducer(dialogState(), DIALOG_ACTIONS.showTagEdit({tagId: 't9'}))
     expect(state.items).toEqual([{id: 't9', tagId: 't9', type: 'tagEdit'}])
   })
 })

--- a/src/modules/notifications/epics.test.ts
+++ b/src/modules/notifications/epics.test.ts
@@ -1,0 +1,346 @@
+// @vitest-environment node
+
+import {describe, expect, it, vi} from 'vitest'
+import {
+  notificationsAssetsDeleteCompleteEpic,
+  notificationsAssetsDeleteErrorEpic,
+  notificationsAssetsTagsAddCompleteEpic,
+  notificationsAssetsTagsRemoveCompleteEpic,
+  notificationsAssetsUpdateCompleteEpic,
+  notificationsAssetsUploadCompleteEpic,
+  notificationsGenericErrorEpic,
+  notificationsTagCreateCompleteEpic,
+  notificationsTagDeleteCompleteEpic,
+  notificationsTagUpdateCompleteEpic
+} from './index'
+import {assetsActions, initialState as assetsInitialState} from '../assets'
+import {ASSETS_ACTIONS} from '../assets/actions'
+import {tagsActions} from '../tags'
+import {uploadsActions} from '../uploads'
+import {createEpicTestStore} from '../../__tests__/fixtures/createEpicTestStore'
+import {createMockSanityClient} from '../../__tests__/fixtures/mockSanityClient'
+import type {AssetItem, AssetType, ImageAsset, Tag} from '../../types'
+
+const sampleAsset = {
+  _id: 'a1',
+  _type: 'sanity.imageAsset',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'r1',
+  originalFilename: 'x.png',
+  size: 1,
+  mimeType: 'image/png',
+  url: 'https://example.com/x.png'
+} as ImageAsset
+
+const sampleAsset2 = {
+  ...sampleAsset,
+  _id: 'a2'
+} as ImageAsset
+
+const sampleTag: Tag = {
+  _id: 't1',
+  _type: 'media.tag',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'tr',
+  name: {_type: 'slug', current: 'alpha'}
+}
+
+const assetItem = (asset: ImageAsset): AssetItem => ({
+  _type: 'asset',
+  asset,
+  picked: false,
+  updating: false
+})
+
+function assetsWithRows(rows: Record<string, AssetItem>) {
+  return {
+    ...assetsInitialState,
+    assetTypes: ['image'] as AssetType[],
+    allIds: Object.keys(rows),
+    byIds: rows
+  }
+}
+
+describe('notificationsAssetsDeleteCompleteEpic', () => {
+  it('adds info notification with pluralized asset count', async () => {
+    const store = createEpicTestStore(
+      notificationsAssetsDeleteCompleteEpic,
+      createMockSanityClient({}),
+      {}
+    )
+    store.dispatch(assetsActions.deleteComplete({assetIds: ['x', 'y']}))
+    await vi.waitFor(() => {
+      expect(store.getState().notifications.items).toEqual([
+        {asset: undefined, status: 'info', title: '2 assets deleted'}
+      ])
+    })
+  })
+})
+
+describe('notificationsAssetsDeleteErrorEpic', () => {
+  it('adds error notification with count', async () => {
+    const store = createEpicTestStore(
+      notificationsAssetsDeleteErrorEpic,
+      createMockSanityClient({}),
+      {
+        assets: assetsWithRows({
+          a1: {...assetItem(sampleAsset), updating: true}
+        })
+      }
+    )
+    store.dispatch(assetsActions.deleteError({assetIds: ['a1'], error: {} as any}))
+    await vi.waitFor(() => {
+      const [n] = store.getState().notifications.items
+      expect(n.status).toBe('error')
+      expect(n.title).toBe(
+        'Unable to delete 1 asset. Please review any asset errors and try again.'
+      )
+    })
+  })
+})
+
+describe('notificationsAssetsUploadCompleteEpic', () => {
+  it('adds info notification from upload check results count', async () => {
+    const store = createEpicTestStore(
+      notificationsAssetsUploadCompleteEpic,
+      createMockSanityClient({}),
+      {}
+    )
+    store.dispatch(
+      uploadsActions.checkComplete({
+        results: {h1: 'id1', h2: null}
+      })
+    )
+    await vi.waitFor(() => {
+      expect(store.getState().notifications.items).toEqual([
+        {asset: undefined, status: 'info', title: 'Uploaded 2 assets'}
+      ])
+    })
+  })
+})
+
+const tagsWithTagUpdating = {
+  allIds: ['t1'],
+  byIds: {
+    t1: {_type: 'tag' as const, tag: sampleTag, picked: false, updating: true}
+  },
+  creating: false,
+  fetchCount: -1,
+  fetching: false,
+  panelVisible: true
+}
+
+describe('notificationsAssetsTagsAddCompleteEpic', () => {
+  it('adds info notification with asset count', async () => {
+    const store = createEpicTestStore(
+      notificationsAssetsTagsAddCompleteEpic,
+      createMockSanityClient({}),
+      {
+        assets: assetsWithRows({
+          a1: {...assetItem(sampleAsset), updating: true},
+          a2: {...assetItem(sampleAsset2), updating: true}
+        }),
+        tags: tagsWithTagUpdating
+      }
+    )
+    store.dispatch(
+      ASSETS_ACTIONS.tagsAddComplete({
+        assets: [assetItem(sampleAsset), assetItem(sampleAsset2)],
+        tag: sampleTag
+      })
+    )
+    await vi.waitFor(() => {
+      expect(store.getState().notifications.items).toEqual([
+        {asset: undefined, status: 'info', title: 'Tag added to 2 assets'}
+      ])
+    })
+  })
+})
+
+describe('notificationsAssetsTagsRemoveCompleteEpic', () => {
+  it('adds info notification with asset count', async () => {
+    const store = createEpicTestStore(
+      notificationsAssetsTagsRemoveCompleteEpic,
+      createMockSanityClient({}),
+      {
+        assets: assetsWithRows({
+          a1: {...assetItem(sampleAsset), updating: true}
+        }),
+        tags: tagsWithTagUpdating
+      }
+    )
+    store.dispatch(
+      ASSETS_ACTIONS.tagsRemoveComplete({
+        assets: [assetItem(sampleAsset)],
+        tag: sampleTag
+      })
+    )
+    await vi.waitFor(() => {
+      expect(store.getState().notifications.items).toEqual([
+        {asset: undefined, status: 'info', title: 'Tag removed from 1 asset'}
+      ])
+    })
+  })
+})
+
+describe('notificationsAssetsUpdateCompleteEpic', () => {
+  it('batches multiple updateComplete actions into one notification after buffer window', async () => {
+    vi.useFakeTimers()
+    const store = createEpicTestStore(
+      notificationsAssetsUpdateCompleteEpic,
+      createMockSanityClient({}),
+      {
+        assets: assetsWithRows({
+          a1: {...assetItem(sampleAsset), updating: true},
+          a2: {...assetItem(sampleAsset2), updating: true}
+        })
+      }
+    )
+
+    store.dispatch(assetsActions.updateComplete({asset: sampleAsset}))
+    store.dispatch(assetsActions.updateComplete({asset: sampleAsset2}))
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(store.getState().notifications.items).toEqual([
+      {asset: undefined, status: 'info', title: '2 assets updated'}
+    ])
+    vi.useRealTimers()
+  })
+
+  it('emits separate notifications when updates fall in different buffer windows', async () => {
+    vi.useFakeTimers()
+    const store = createEpicTestStore(
+      notificationsAssetsUpdateCompleteEpic,
+      createMockSanityClient({}),
+      {
+        assets: assetsWithRows({
+          a1: {...assetItem(sampleAsset), updating: true},
+          a2: {...assetItem(sampleAsset2), updating: true}
+        })
+      }
+    )
+
+    store.dispatch(assetsActions.updateComplete({asset: sampleAsset}))
+    await vi.advanceTimersByTimeAsync(2000)
+    store.dispatch(assetsActions.updateComplete({asset: sampleAsset2}))
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(store.getState().notifications.items).toEqual([
+      {asset: undefined, status: 'info', title: '1 asset updated'},
+      {asset: undefined, status: 'info', title: '1 asset updated'}
+    ])
+    vi.useRealTimers()
+  })
+})
+
+describe('notificationsGenericErrorEpic', () => {
+  it('maps assets.updateError to error notification title', async () => {
+    const store = createEpicTestStore(notificationsGenericErrorEpic, createMockSanityClient({}), {
+      assets: assetsWithRows({
+        a1: {...assetItem(sampleAsset), updating: true}
+      })
+    })
+    store.dispatch(
+      assetsActions.updateError({
+        asset: sampleAsset,
+        error: {message: 'patch failed', statusCode: 500}
+      })
+    )
+    await vi.waitFor(() => {
+      expect(store.getState().notifications.items).toEqual([
+        {asset: undefined, status: 'error', title: 'An error occured: patch failed'}
+      ])
+    })
+  })
+
+  it('maps tags.createError to error notification title', async () => {
+    const store = createEpicTestStore(notificationsGenericErrorEpic, createMockSanityClient({}), {
+      tags: {creating: true, creatingError: undefined, allIds: [], byIds: {}, fetchCount: -1, fetching: false, panelVisible: true} as any
+    })
+    store.dispatch(
+      tagsActions.createError({
+        name: 'n',
+        error: {message: 'tag create', statusCode: 400}
+      })
+    )
+    await vi.waitFor(() => {
+      expect(store.getState().notifications.items[0].title).toBe('An error occured: tag create')
+    })
+  })
+
+  it('maps uploads.uploadError to error notification title', async () => {
+    const store = createEpicTestStore(notificationsGenericErrorEpic, createMockSanityClient({}), {
+      uploads: {allIds: ['h'], byIds: {h: {} as any}}
+    })
+    store.dispatch(
+      uploadsActions.uploadError({
+        hash: 'h',
+        error: {message: 'upload bad', statusCode: 413}
+      })
+    )
+    await vi.waitFor(() => {
+      expect(store.getState().notifications.items[0].title).toBe('An error occured: upload bad')
+    })
+  })
+})
+
+describe('notificationsTagCreateCompleteEpic', () => {
+  it('adds tag created notification', async () => {
+    const store = createEpicTestStore(
+      notificationsTagCreateCompleteEpic,
+      createMockSanityClient({}),
+      {}
+    )
+    store.dispatch(tagsActions.createComplete({tag: sampleTag}))
+    await vi.waitFor(() => {
+      expect(store.getState().notifications.items).toEqual([
+        {asset: undefined, status: 'info', title: 'Tag created'}
+      ])
+    })
+  })
+})
+
+describe('notificationsTagDeleteCompleteEpic', () => {
+  it('adds tag deleted notification', async () => {
+    const store = createEpicTestStore(
+      notificationsTagDeleteCompleteEpic,
+      createMockSanityClient({}),
+      {}
+    )
+    store.dispatch(tagsActions.deleteComplete({tagId: 't1'}))
+    await vi.waitFor(() => {
+      expect(store.getState().notifications.items).toEqual([
+        {asset: undefined, status: 'info', title: 'Tag deleted'}
+      ])
+    })
+  })
+})
+
+describe('notificationsTagUpdateCompleteEpic', () => {
+  it('adds tag updated notification', async () => {
+    const store = createEpicTestStore(
+      notificationsTagUpdateCompleteEpic,
+      createMockSanityClient({}),
+      {
+        tags: {
+          allIds: ['t1'],
+          byIds: {
+            t1: {_type: 'tag', tag: sampleTag, picked: false, updating: true}
+          },
+          creating: false,
+          fetchCount: -1,
+          fetching: false,
+          panelVisible: true
+        }
+      }
+    )
+    store.dispatch(tagsActions.updateComplete({tag: sampleTag}))
+    await vi.waitFor(() => {
+      expect(store.getState().notifications.items).toEqual([
+        {asset: undefined, status: 'info', title: 'Tag updated'}
+      ])
+    })
+  })
+})

--- a/src/modules/notifications/epics.test.ts
+++ b/src/modules/notifications/epics.test.ts
@@ -257,7 +257,15 @@ describe('notificationsGenericErrorEpic', () => {
 
   it('maps tags.createError to error notification title', async () => {
     const store = createEpicTestStore(notificationsGenericErrorEpic, createMockSanityClient({}), {
-      tags: {creating: true, creatingError: undefined, allIds: [], byIds: {}, fetchCount: -1, fetching: false, panelVisible: true} as any
+      tags: {
+        creating: true,
+        creatingError: undefined,
+        allIds: [],
+        byIds: {},
+        fetchCount: -1,
+        fetching: false,
+        panelVisible: true
+      } as any
     })
     store.dispatch(
       tagsActions.createError({

--- a/src/modules/notifications/epics.test.ts
+++ b/src/modules/notifications/epics.test.ts
@@ -250,7 +250,7 @@ describe('notificationsGenericErrorEpic', () => {
     )
     await vi.waitFor(() => {
       expect(store.getState().notifications.items).toEqual([
-        {asset: undefined, status: 'error', title: 'An error occured: patch failed'}
+        {asset: undefined, status: 'error', title: 'An error occurred: patch failed'}
       ])
     })
   })
@@ -274,7 +274,7 @@ describe('notificationsGenericErrorEpic', () => {
       })
     )
     await vi.waitFor(() => {
-      expect(store.getState().notifications.items[0].title).toBe('An error occured: tag create')
+      expect(store.getState().notifications.items[0].title).toBe('An error occurred: tag create')
     })
   })
 
@@ -289,7 +289,7 @@ describe('notificationsGenericErrorEpic', () => {
       })
     )
     await vi.waitFor(() => {
-      expect(store.getState().notifications.items[0].title).toBe('An error occured: upload bad')
+      expect(store.getState().notifications.items[0].title).toBe('An error occurred: upload bad')
     })
   })
 })

--- a/src/modules/notifications/epics.test.ts
+++ b/src/modules/notifications/epics.test.ts
@@ -255,6 +255,25 @@ describe('notificationsGenericErrorEpic', () => {
     })
   })
 
+  it('maps assets.fetchError (bare HttpError payload) to error notification title', async () => {
+    const store = createEpicTestStore(notificationsGenericErrorEpic, createMockSanityClient({}), {
+      assets: {
+        ...assetsInitialState,
+        assetTypes: ['image'] as AssetType[],
+        fetching: true
+      }
+    })
+    store.dispatch(
+      assetsActions.fetchError({
+        message: 'fetch failed',
+        statusCode: 503
+      })
+    )
+    await vi.waitFor(() => {
+      expect(store.getState().notifications.items[0].title).toBe('An error occurred: fetch failed')
+    })
+  })
+
   it('maps tags.createError to error notification title', async () => {
     const store = createEpicTestStore(notificationsGenericErrorEpic, createMockSanityClient({}), {
       tags: {

--- a/src/modules/notifications/index.ts
+++ b/src/modules/notifications/index.ts
@@ -149,7 +149,7 @@ export const notificationsGenericErrorEpic: MyEpic = action$ =>
       return of(
         notificationsSlice.actions.add({
           status: 'error',
-          title: `An error occured: ${error.message}`
+          title: `An error occurred: ${error.message}`
         })
       )
     })

--- a/src/modules/notifications/index.ts
+++ b/src/modules/notifications/index.ts
@@ -1,5 +1,6 @@
 import {type PayloadAction, createSlice} from '@reduxjs/toolkit'
-import type {ImageAsset, MyEpic} from '../../types'
+import type {AnyAction} from 'redux'
+import type {HttpError, ImageAsset, MyEpic} from '../../types'
 import pluralize from 'pluralize'
 import {ofType} from 'redux-observable'
 import {of} from 'rxjs'
@@ -17,6 +18,25 @@ type Notification = {
 
 type NotificationsReducerState = {
   items: Notification[]
+}
+
+function messageFromGenericErrorPayload(payload: unknown): string {
+  if (!payload || typeof payload !== 'object') {
+    return 'Unknown error'
+  }
+  if (
+    'error' in payload &&
+    payload.error &&
+    typeof payload.error === 'object' &&
+    payload.error !== null &&
+    'message' in payload.error
+  ) {
+    return String((payload.error as HttpError).message)
+  }
+  if ('message' in payload && typeof (payload as HttpError).message === 'string') {
+    return String((payload as HttpError).message)
+  }
+  return 'Unknown error'
 }
 
 const initialState = {
@@ -144,12 +164,12 @@ export const notificationsGenericErrorEpic: MyEpic = action$ =>
       tagsActions.updateError.type,
       uploadsActions.uploadError.type
     ),
-    mergeMap((action: {payload: {error: {message: string}}}) => {
-      const error = action.payload?.error
+    mergeMap((action: AnyAction) => {
+      const title = `An error occurred: ${messageFromGenericErrorPayload(action.payload)}`
       return of(
         notificationsSlice.actions.add({
           status: 'error',
-          title: `An error occurred: ${error.message}`
+          title
         })
       )
     })

--- a/src/modules/notifications/reducer.test.ts
+++ b/src/modules/notifications/reducer.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+
+import {describe, expect, it} from 'vitest'
+import notificationsReducer, {notificationsActions} from './index'
+import type {ImageAsset} from '../../types'
+import {createTestRootState} from '../../__tests__/fixtures/rootState'
+
+const sampleAsset = {
+  _id: 'a1',
+  _type: 'sanity.imageAsset',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'r1',
+  originalFilename: 'x.png',
+  size: 1,
+  mimeType: 'image/png',
+  url: 'https://example.com/x.png'
+} as ImageAsset
+
+describe('notificationsReducer', () => {
+  it('starts with no items', () => {
+    const state = notificationsReducer(undefined, {type: '@@init'})
+    expect(state.items).toEqual([])
+  })
+
+  it('add appends a notification with asset, status, and title', () => {
+    const prev = createTestRootState().notifications
+    const next = notificationsReducer(
+      prev,
+      notificationsActions.add({
+        asset: sampleAsset,
+        status: 'success',
+        title: 'Done'
+      })
+    )
+    expect(next.items).toHaveLength(1)
+    expect(next.items[0]).toEqual({
+      asset: sampleAsset,
+      status: 'success',
+      title: 'Done'
+    })
+  })
+
+  it('add allows partial payloads', () => {
+    let state = createTestRootState().notifications
+    state = notificationsReducer(state, notificationsActions.add({status: 'error', title: 'X'}))
+    state = notificationsReducer(state, notificationsActions.add({title: 'Y'}))
+    expect(state.items).toEqual([
+      {asset: undefined, status: 'error', title: 'X'},
+      {asset: undefined, status: undefined, title: 'Y'}
+    ])
+  })
+})

--- a/src/modules/search/index.test.ts
+++ b/src/modules/search/index.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment node
+
+import {describe, expect, it} from 'vitest'
+import searchReducer, {searchActions} from './index'
+import {inputs} from '../../config/searchFacets'
+
+describe('search slice', () => {
+  it('facetsAdd assigns an id and appends facet', () => {
+    let state = searchReducer(undefined, {type: '@@INIT'} as never)
+    state = searchReducer(state, searchActions.facetsAdd({facet: {...inputs.title}}))
+    expect(state.facets).toHaveLength(1)
+    expect(state.facets[0].name).toBe('title')
+    expect(state.facets[0].id).toBeDefined()
+  })
+
+  it('querySet updates search string', () => {
+    let state = searchReducer(undefined, {type: '@@INIT'} as never)
+    state = searchReducer(state, searchActions.querySet({searchQuery: 'cats'}))
+    expect(state.query).toBe('cats')
+  })
+
+  it('facetsClear removes all facets', () => {
+    let state = searchReducer(undefined, {type: '@@INIT'} as never)
+    state = searchReducer(state, searchActions.facetsAdd({facet: {...inputs.title}}))
+    state = searchReducer(state, searchActions.facetsClear())
+    expect(state.facets).toHaveLength(0)
+  })
+
+  it('facetsRemoveByName filters facets', () => {
+    let state = searchReducer(undefined, {type: '@@INIT'} as never)
+    state = searchReducer(state, searchActions.facetsAdd({facet: {...inputs.title}}))
+    state = searchReducer(state, searchActions.facetsRemoveByName({facetName: 'title'}))
+    expect(state.facets).toHaveLength(0)
+  })
+})

--- a/src/modules/selectors.test.ts
+++ b/src/modules/selectors.test.ts
@@ -1,0 +1,20 @@
+// @vitest-environment node
+
+import {describe, expect, it} from 'vitest'
+import type {RootReducerState} from './types'
+import {selectCombinedItems} from './selectors'
+
+describe('selectCombinedItems', () => {
+  it('places upload items before asset items', () => {
+    const state = {
+      assets: {allIds: ['a1', 'a2']},
+      uploads: {allIds: ['u1']}
+    } as RootReducerState
+
+    expect(selectCombinedItems(state)).toEqual([
+      {id: 'u1', type: 'upload'},
+      {id: 'a1', type: 'asset'},
+      {id: 'a2', type: 'asset'}
+    ])
+  })
+})

--- a/src/modules/tags/epics.test.ts
+++ b/src/modules/tags/epics.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+
+import {describe, expect, it, vi} from 'vitest'
+import {of} from 'rxjs'
+import {tagsCreateEpic, tagsDeleteEpic, tagsActions} from './index'
+import {createEpicTestStore} from '../../__tests__/fixtures/createEpicTestStore'
+import {
+  createMockSanityClient,
+  mockTransactionCommit
+} from '../../__tests__/fixtures/mockSanityClient'
+import type {Tag} from '../../types'
+
+const sampleTag: Tag = {
+  _id: 't1',
+  _type: 'media.tag',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'tr',
+  name: {_type: 'slug', current: 'alpha'}
+}
+
+describe('tagsCreateEpic', () => {
+  it('creates tag when checkTagName passes', async () => {
+    const client = createMockSanityClient({
+      fetch: vi.fn().mockResolvedValue(0),
+      observable: {
+        create: vi.fn(() => of(sampleTag))
+      }
+    })
+
+    const store = createEpicTestStore(tagsCreateEpic, client)
+    store.dispatch(tagsActions.createRequest({name: 'alpha'}))
+
+    await vi.waitFor(() => {
+      expect(store.getState().tags.byIds.t1?.tag).toEqual(sampleTag)
+      expect(client.observable.create).toHaveBeenCalled()
+    })
+  })
+
+  it('dispatches createError when tag exists', async () => {
+    const client = createMockSanityClient({
+      fetch: vi.fn().mockResolvedValue(1),
+      observable: {
+        create: vi.fn(() => of(sampleTag))
+      }
+    })
+
+    const store = createEpicTestStore(tagsCreateEpic, client)
+    store.dispatch(tagsActions.createRequest({name: 'dup'}))
+
+    await vi.waitFor(() => {
+      expect(store.getState().tags.creatingError?.statusCode).toBe(409)
+      expect(client.observable.create).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('tagsDeleteEpic', () => {
+  it('fetches referencing assets and commits transaction', async () => {
+    const tx = mockTransactionCommit(undefined)
+    const client = createMockSanityClient({
+      observable: {
+        fetch: vi.fn(() =>
+          of([
+            {_id: 'a1', _rev: 'r1', opt: {}},
+            {_id: 'a2', _rev: 'r2', opt: {}}
+          ])
+        )
+      },
+      transaction: vi.fn(() => tx)
+    })
+
+    const store = createEpicTestStore(tagsDeleteEpic, client, {
+      tags: {
+        allIds: ['t1'],
+        byIds: {
+          t1: {_type: 'tag', tag: sampleTag, picked: false, updating: false}
+        },
+        creating: false,
+        fetchCount: -1,
+        fetching: false,
+        panelVisible: true
+      }
+    })
+
+    store.dispatch(tagsActions.deleteRequest({tag: sampleTag}))
+
+    await vi.waitFor(() => {
+      expect(tx.patch).toHaveBeenCalled()
+      expect(tx.delete).toHaveBeenCalledWith('t1')
+      expect(tx.commit).toHaveBeenCalled()
+      expect(store.getState().tags.byIds.t1).toBeUndefined()
+    })
+  })
+})

--- a/src/modules/tags/index.test.ts
+++ b/src/modules/tags/index.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+
+import {describe, expect, it} from 'vitest'
+import type {Tag} from '../../types'
+import tagsReducer, {tagsActions} from './index'
+
+const sampleTag: Tag = {
+  _id: 'tag-1',
+  _type: 'media.tag',
+  _createdAt: '2020-01-01',
+  _updatedAt: '2020-01-01',
+  _rev: 'r1',
+  name: {_type: 'slug', current: 'alpha'}
+}
+
+describe('tags slice', () => {
+  it('createComplete adds tag', () => {
+    let state = tagsReducer(undefined, {type: '@@INIT'} as never)
+    state = tagsReducer(state, tagsActions.createComplete({tag: sampleTag}))
+    expect(state.allIds).toContain('tag-1')
+    expect(state.byIds['tag-1'].tag).toEqual(sampleTag)
+    expect(state.creating).toBe(false)
+  })
+
+  it('deleteComplete removes tag', () => {
+    let state = tagsReducer(undefined, {type: '@@INIT'} as never)
+    state = tagsReducer(state, tagsActions.createComplete({tag: sampleTag}))
+    state = tagsReducer(state, tagsActions.deleteComplete({tagId: 'tag-1'}))
+    expect(state.allIds).not.toContain('tag-1')
+    expect(state.byIds['tag-1']).toBeUndefined()
+  })
+
+  it('fetchComplete hydrates tag list', () => {
+    let state = tagsReducer(undefined, {type: '@@INIT'} as never)
+    state = tagsReducer(state, tagsActions.fetchRequest())
+    expect(state.fetching).toBe(true)
+    state = tagsReducer(state, tagsActions.fetchComplete({tags: [sampleTag]}))
+    expect(state.fetching).toBe(false)
+    expect(state.byIds['tag-1'].tag).toEqual(sampleTag)
+  })
+})

--- a/src/modules/uploads/epics.test.ts
+++ b/src/modules/uploads/epics.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import {describe, expect, it, vi, beforeEach, afterEach} from 'vitest'
+import {of} from 'rxjs'
+import {uploadsAssetStartEpic, uploadsCheckRequestEpic, uploadsActions} from './index'
+import {createEpicTestStore} from '../../__tests__/fixtures/createEpicTestStore'
+import {createMockSanityClient} from '../../__tests__/fixtures/mockSanityClient'
+import {initialState as assetsInitialState} from '../assets'
+import type {SanityImageAssetDocument} from '@sanity/client'
+
+vi.mock('../../utils/generatePreviewBlobUrl', () => ({
+  generatePreviewBlobUrl$: () => of('blob:http://preview')
+}))
+
+const uploadedAsset = {
+  _id: 'asset-new',
+  _type: 'sanity.imageAsset',
+  sha1hash: 'deadbeef',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'r',
+  originalFilename: 'f.png',
+  mimeType: 'image/png',
+  size: 10,
+  url: ''
+} as SanityImageAssetDocument
+
+vi.mock('../../utils/uploadSanityAsset', () => ({
+  uploadAsset$: () =>
+    of({
+      type: 'complete' as const,
+      asset: uploadedAsset
+    }),
+  hashFile$: () => of('deadbeef'),
+  withMaxConcurrency: (fn: unknown) => fn
+}))
+
+describe('uploadsAssetStartEpic', () => {
+  it('dispatches preview, progress path, and uploadComplete', async () => {
+    const client = createMockSanityClient()
+
+    const store = createEpicTestStore(uploadsAssetStartEpic, client)
+
+    const file = new File(['x'], 'f.png', {type: 'image/png'})
+    const uploadItem = {
+      _type: 'upload' as const,
+      assetType: 'image' as const,
+      hash: 'deadbeef',
+      name: 'f.png',
+      size: file.size,
+      status: 'queued' as const
+    }
+
+    store.dispatch(uploadsActions.uploadStart({file, uploadItem}))
+
+    await vi.waitFor(() => {
+      expect(store.getState().uploads.byIds.deadbeef?.objectUrl).toBe('blob:http://preview')
+    })
+
+    await vi.waitFor(() => {
+      expect(store.getState().assets.byIds['asset-new']).toBeDefined()
+    })
+  })
+})
+
+describe('uploadsCheckRequestEpic', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('after delay, fetches sha hashes and dispatches checkComplete + insertUploads', async () => {
+    const client = createMockSanityClient({
+      observable: {
+        fetch: vi.fn(() => of(['hh']))
+      }
+    })
+
+    const store = createEpicTestStore(uploadsCheckRequestEpic, client, {
+      assets: {...assetsInitialState, assetTypes: ['image']}
+    })
+
+    const asset = {
+      _id: 'id-1',
+      _type: 'sanity.imageAsset',
+      sha1hash: 'hh',
+      _createdAt: '',
+      _updatedAt: '',
+      _rev: 'r',
+      originalFilename: 'f.png',
+      mimeType: 'image/png',
+      size: 1,
+      url: ''
+    } as SanityImageAssetDocument
+
+    store.dispatch(uploadsActions.checkRequest({assets: [asset]}))
+
+    await vi.advanceTimersByTimeAsync(1100)
+
+    await vi.waitFor(() => {
+      expect(client.observable.fetch).toHaveBeenCalled()
+      expect(store.getState().uploads.byIds.hh).toBeUndefined()
+    })
+  })
+})

--- a/src/modules/uploads/index.test.ts
+++ b/src/modules/uploads/index.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+
+import {describe, expect, it} from 'vitest'
+import type {UploadItem} from '../../types'
+import uploadsReducer, {uploadsActions} from './index'
+
+describe('uploads slice', () => {
+  it('uploadStart adds item to queue', () => {
+    let state = uploadsReducer(undefined, {type: '@@INIT'} as never)
+    const uploadItem = {
+      _type: 'upload',
+      assetType: 'image',
+      hash: 'abc',
+      name: 'x.png',
+      size: 1,
+      status: 'queued'
+    } as UploadItem
+
+    state = uploadsReducer(
+      state,
+      uploadsActions.uploadStart({
+        file: new File([], 'x.png'),
+        uploadItem
+      })
+    )
+
+    expect(state.allIds).toEqual(['abc'])
+    expect(state.byIds.abc).toMatchObject({hash: 'abc', status: 'queued'})
+  })
+
+  it('uploadProgress updates percent and status', () => {
+    let state = uploadsReducer(undefined, {type: '@@INIT'} as never)
+    const uploadItem = {
+      _type: 'upload',
+      assetType: 'image',
+      hash: 'h1',
+      name: 'x.png',
+      size: 1,
+      status: 'queued',
+      percent: 0
+    } as UploadItem
+
+    state = uploadsReducer(
+      state,
+      uploadsActions.uploadStart({file: new File([], 'x.png'), uploadItem})
+    )
+    state = uploadsReducer(
+      state,
+      uploadsActions.uploadProgress({
+        uploadHash: 'h1',
+        event: {percent: 42, stage: 'upload'} as any
+      })
+    )
+
+    expect(state.byIds.h1.percent).toBe(42)
+    expect(state.byIds.h1.status).toBe('uploading')
+  })
+})

--- a/src/operators/checkTagName.test.ts
+++ b/src/operators/checkTagName.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment node
+
+import {describe, expect, it, vi} from 'vitest'
+import {firstValueFrom, of} from 'rxjs'
+import type {SanityClient} from '@sanity/client'
+import checkTagName from './checkTagName'
+
+describe('checkTagName', () => {
+  it('errors with 409 when a tag with the same slug exists', async () => {
+    const client = {
+      fetch: vi.fn().mockResolvedValue(1)
+    } as unknown as SanityClient
+
+    await expect(
+      firstValueFrom(of(null).pipe(checkTagName(client, 'existing')))
+    ).rejects.toMatchObject({statusCode: 409, message: 'Tag already exists'})
+  })
+
+  it('emits true when name is available', async () => {
+    const client = {
+      fetch: vi.fn().mockResolvedValue(0)
+    } as unknown as SanityClient
+
+    await expect(firstValueFrom(of(null).pipe(checkTagName(client, 'fresh-name')))).resolves.toBe(
+      true
+    )
+  })
+})

--- a/src/utils/blocksToText.test.ts
+++ b/src/utils/blocksToText.test.ts
@@ -1,0 +1,42 @@
+import {describe, expect, it} from 'vitest'
+import blocksToText from './blocksToText'
+import type {Block} from '../types'
+
+describe('blocksToText', () => {
+  it('returns plain strings unchanged', () => {
+    expect(blocksToText('hello')).toBe('hello')
+    expect(blocksToText('')).toBe('')
+  })
+
+  it('returns empty string for non-array non-string input', () => {
+    expect(blocksToText(null as unknown as string)).toBe('')
+  })
+
+  it('joins block children text with blank lines between blocks', () => {
+    const blocks: Block[] = [
+      {
+        _type: 'block',
+        _key: 'a',
+        markDefs: [],
+        children: [{_key: 'a1', text: 'Line one', marks: []}]
+      },
+      {
+        _type: 'block',
+        _key: 'b',
+        markDefs: [],
+        children: [{_key: 'b1', text: 'Line two', marks: []}]
+      }
+    ]
+    expect(blocksToText(blocks)).toBe('Line one\n\nLine two')
+  })
+
+  it('removes non-block nodes by default', () => {
+    const blocks = [{_type: 'image', _key: 'i', markDefs: [], children: []}] as unknown as Block[]
+    expect(blocksToText(blocks)).toBe('')
+  })
+
+  it('keeps placeholder for non-block nodes when nonTextBehavior is not remove', () => {
+    const blocks = [{_type: 'image', _key: 'i', markDefs: [], children: []}] as unknown as Block[]
+    expect(blocksToText(blocks, {nonTextBehavior: 'keep'})).toBe('[image block]')
+  })
+})

--- a/src/utils/constructFilter.test.ts
+++ b/src/utils/constructFilter.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment node
+
+import {describe, expect, it} from 'vitest'
+import {inputs} from '../config/searchFacets'
+import type {SearchFacetInputProps} from '../types'
+import constructFilter from './constructFilter'
+
+describe('constructFilter', () => {
+  it('includes base filter that excludes drafts and restricts asset types', () => {
+    const q = constructFilter({
+      assetTypes: ['image', 'file'],
+      searchFacets: [],
+      searchQuery: undefined
+    })
+
+    expect(q).toContain('_type in ["sanity.imageAsset","sanity.fileAsset"]')
+    expect(q).toContain('!(_id in path("drafts.**"))')
+  })
+
+  it('limits to a single asset type in picker mode', () => {
+    const q = constructFilter({
+      assetTypes: ['image'],
+      searchFacets: [],
+      searchQuery: undefined
+    })
+
+    expect(q).toContain('_type in ["sanity.imageAsset"]')
+  })
+
+  it('appends text search on trimmed query', () => {
+    const q = constructFilter({
+      assetTypes: ['file', 'image'],
+      searchFacets: [],
+      searchQuery: '  hello  '
+    })
+
+    expect(q).toContain(
+      "[_id, altText, assetId, creditLine, description, originalFilename, title, url] match '*hello*'"
+    )
+  })
+
+  it('composes number facet with field modifier (size / KB)', () => {
+    const q = constructFilter({
+      assetTypes: ['image'],
+      searchFacets: [{...inputs.size, value: 500} as SearchFacetInputProps],
+      searchQuery: undefined
+    })
+
+    expect(q.replace(/\s+/g, ' ')).toContain('round(size / 1000) > 500')
+  })
+
+  it('composes searchable tag facet (references)', () => {
+    const facet = {
+      ...inputs.tag,
+      operatorType: 'references' as const,
+      value: {label: 'T', value: 'tag-id-1'}
+    } as SearchFacetInputProps
+
+    const q = constructFilter({
+      assetTypes: ['image', 'file'],
+      searchFacets: [facet],
+      searchQuery: undefined
+    })
+
+    expect(q).toContain("references('tag-id-1')")
+  })
+
+  it('composes select facet (inUse)', () => {
+    const q = constructFilter({
+      assetTypes: ['image', 'file'],
+      searchFacets: [structuredClone(inputs.inUse)],
+      searchQuery: undefined
+    })
+
+    expect(q).toContain('count(*[references(^._id)]) > 0')
+  })
+
+  it('AND-joins base filter, search text, and multiple facets', () => {
+    const q = constructFilter({
+      assetTypes: ['image', 'file'],
+      searchFacets: [{...inputs.title}, {...inputs.inUse}],
+      searchQuery: 'x'
+    })
+
+    const parts = q.split(' && ')
+    expect(parts.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('matches snapshot for stable GROQ shape (apiVersion / filter regressions)', () => {
+    const q = constructFilter({
+      assetTypes: ['file', 'image'],
+      searchFacets: [
+        {...inputs.size, value: 100} as SearchFacetInputProps,
+        {
+          ...inputs.tag,
+          operatorType: 'references',
+          value: {label: 'Example', value: 'abc123'}
+        } as SearchFacetInputProps
+      ],
+      searchQuery: 'portrait'
+    })
+
+    const normalized = q.replace(/\s+/g, ' ').trim()
+
+    expect(normalized).toBe(
+      '_type in ["sanity.fileAsset","sanity.imageAsset"] && !(_id in path("drafts.**")) && [_id, altText, assetId, creditLine, description, originalFilename, title, url] match \'*portrait*\' && round(size / 1000) > 100 && references(\'abc123\')'
+    )
+  })
+
+  it('omits text search fragment when searchQuery is undefined', () => {
+    const q = constructFilter({
+      assetTypes: ['image', 'file'],
+      searchFacets: [],
+      searchQuery: undefined
+    })
+
+    expect(q).not.toContain('match ')
+  })
+})

--- a/src/utils/generatePreviewBlobUrl.test.ts
+++ b/src/utils/generatePreviewBlobUrl.test.ts
@@ -10,7 +10,12 @@ describe('generatePreviewBlobUrl$', () => {
       onload: (() => void) | null = null
       width = 400
       height = 200
-      set src(_v: string) {
+      private _src = ''
+      get src() {
+        return this._src
+      }
+      set src(v: string) {
+        this._src = v
         queueMicrotask(() => this.onload?.())
       }
     }
@@ -22,9 +27,13 @@ describe('generatePreviewBlobUrl$', () => {
         vi.spyOn(el, 'getContext').mockReturnValue({
           drawImage: vi.fn()
         } as unknown as CanvasRenderingContext2D)
-        el.toBlob = cb => {
-          cb?.(new Blob(['x'], {type: 'image/jpeg'}))
+        /* eslint-disable callback-return, consistent-return -- HTMLCanvasElement#toBlob sync test stub */
+        el.toBlob = function toBlob(cb: ((blob: Blob | null) => void) | null | undefined) {
+          if (cb) {
+            cb(new Blob(['x'], {type: 'image/jpeg'}))
+          }
         }
+        /* eslint-enable callback-return, consistent-return */
         return el
       }
       return origCreateElement(tagName)
@@ -32,8 +41,16 @@ describe('generatePreviewBlobUrl$', () => {
 
     const createObjectURL = vi.fn(() => 'blob:mock-preview')
     const revokeObjectURL = vi.fn()
-    Object.defineProperty(URL, 'createObjectURL', {configurable: true, writable: true, value: createObjectURL})
-    Object.defineProperty(URL, 'revokeObjectURL', {configurable: true, writable: true, value: revokeObjectURL})
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      writable: true,
+      value: createObjectURL
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      writable: true,
+      value: revokeObjectURL
+    })
   })
 
   afterEach(() => {

--- a/src/utils/generatePreviewBlobUrl.test.ts
+++ b/src/utils/generatePreviewBlobUrl.test.ts
@@ -1,0 +1,52 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {firstValueFrom} from 'rxjs'
+import {generatePreviewBlobUrl$} from './generatePreviewBlobUrl'
+
+describe('generatePreviewBlobUrl$', () => {
+  const origCreateElement = document.createElement.bind(document)
+
+  beforeEach(() => {
+    class MockImage {
+      onload: (() => void) | null = null
+      width = 400
+      height = 200
+      set src(_v: string) {
+        queueMicrotask(() => this.onload?.())
+      }
+    }
+    vi.stubGlobal('Image', MockImage)
+
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'canvas') {
+        const el = origCreateElement('canvas')
+        vi.spyOn(el, 'getContext').mockReturnValue({
+          drawImage: vi.fn()
+        } as unknown as CanvasRenderingContext2D)
+        el.toBlob = cb => {
+          cb?.(new Blob(['x'], {type: 'image/jpeg'}))
+        }
+        return el
+      }
+      return origCreateElement(tagName)
+    })
+
+    const createObjectURL = vi.fn(() => 'blob:mock-preview')
+    const revokeObjectURL = vi.fn()
+    Object.defineProperty(URL, 'createObjectURL', {configurable: true, writable: true, value: createObjectURL})
+    Object.defineProperty(URL, 'revokeObjectURL', {configurable: true, writable: true, value: revokeObjectURL})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    delete (URL as Partial<typeof URL> & {createObjectURL?: unknown}).createObjectURL
+    delete (URL as Partial<typeof URL> & {revokeObjectURL?: unknown}).revokeObjectURL
+  })
+
+  it('emits a blob URL when canvas preview succeeds', async () => {
+    const url = await firstValueFrom(
+      generatePreviewBlobUrl$(new File(['x'], 'photo.jpg', {type: 'image/jpeg'}))
+    )
+    expect(url).toBe('blob:mock-preview')
+  })
+})

--- a/src/utils/getAssetResolution.test.ts
+++ b/src/utils/getAssetResolution.test.ts
@@ -1,0 +1,12 @@
+import {describe, expect, it} from 'vitest'
+import getAssetResolution from './getAssetResolution'
+import type {ImageAsset} from '../types'
+
+describe('getAssetResolution', () => {
+  it('formats width x height with px suffix', () => {
+    const asset = {
+      metadata: {dimensions: {width: 1920, height: 1080}}
+    } as ImageAsset
+    expect(getAssetResolution(asset)).toBe('1920x1080px')
+  })
+})

--- a/src/utils/getDocumentAssetIds.test.ts
+++ b/src/utils/getDocumentAssetIds.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+
+import {describe, expect, it} from 'vitest'
+import getDocumentAssetIds from './getDocumentAssetIds'
+
+describe('getDocumentAssetIds', () => {
+  it('returns empty array for document without asset refs', () => {
+    expect(getDocumentAssetIds({_id: 'doc1', _type: 'post'} as any)).toEqual([])
+  })
+
+  it('collects asset _ref from nested portable text–like structures', () => {
+    const doc = {
+      _id: 'doc1',
+      _type: 'post',
+      body: [
+        {
+          _type: 'block',
+          asset: {_type: 'reference', _ref: 'image-asset-1'}
+        }
+      ]
+    } as any
+
+    expect(getDocumentAssetIds(doc)).toEqual(['image-asset-1'])
+  })
+
+  it('dedupes and sorts refs', () => {
+    const doc = {
+      _id: 'doc1',
+      _type: 'post',
+      modules: [
+        {image: {asset: {_type: 'reference', _ref: 'b'}}},
+        {image: {asset: {_type: 'reference', _ref: 'a'}}},
+        {image: {asset: {_type: 'reference', _ref: 'b'}}}
+      ]
+    } as any
+
+    expect(getDocumentAssetIds(doc)).toEqual(['a', 'b'])
+  })
+
+  it('ignores reference nodes that are not asset references', () => {
+    const doc = {
+      _id: 'doc1',
+      _type: 'post',
+      author: {_type: 'reference', _ref: 'person-1'}
+    } as any
+
+    expect(getDocumentAssetIds(doc)).toEqual([])
+  })
+})

--- a/src/utils/getSchemeColor.test.ts
+++ b/src/utils/getSchemeColor.test.ts
@@ -1,0 +1,11 @@
+import {describe, expect, it} from 'vitest'
+import {getSchemeColor} from './getSchemeColor'
+
+describe('getSchemeColor', () => {
+  it('returns a hex or theme string for light and dark schemes', () => {
+    expect(getSchemeColor('light', 'bg')).toMatch(/^#/)
+    expect(getSchemeColor('dark', 'bg')).toMatch(/^#/)
+    expect(getSchemeColor('light', 'spotBlue')).toBeTruthy()
+    expect(getSchemeColor('dark', 'inputEnabledBorder')).toBeTruthy()
+  })
+})

--- a/src/utils/getTagSelectOptions.test.ts
+++ b/src/utils/getTagSelectOptions.test.ts
@@ -1,0 +1,43 @@
+import {describe, expect, it} from 'vitest'
+import getTagSelectOptions from './getTagSelectOptions'
+import type {Tag, TagItem} from '../types'
+
+function tagItem(partial: Partial<TagItem> & Pick<TagItem, 'tag'>): TagItem {
+  return {
+    _type: 'tag',
+    picked: false,
+    updating: false,
+    ...partial
+  }
+}
+
+const makeTag = (id: string, name: string): Tag => ({
+  _id: id,
+  _type: 'media.tag',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'r1',
+  name: {_type: 'slug', current: name}
+})
+
+describe('getTagSelectOptions', () => {
+  it('maps tag items to label/value options', () => {
+    const tags = [tagItem({tag: makeTag('t1', 'alpha')}), tagItem({tag: makeTag('t2', 'beta')})]
+    expect(getTagSelectOptions(tags)).toEqual([
+      {label: 'alpha', value: 't1'},
+      {label: 'beta', value: 't2'}
+    ])
+  })
+
+  it('returns an empty array for an empty list', () => {
+    expect(getTagSelectOptions([])).toEqual([])
+  })
+
+  it('skips items without a tag', () => {
+    const tags = [
+      tagItem({tag: makeTag('t1', 'ok')}),
+      {_type: 'tag', tag: undefined, picked: false, updating: false} as unknown as TagItem
+    ]
+    expect(getTagSelectOptions(tags)).toEqual([{label: 'ok', value: 't1'}])
+  })
+})

--- a/src/utils/getUniqueDocuments.test.ts
+++ b/src/utils/getUniqueDocuments.test.ts
@@ -1,0 +1,25 @@
+import {describe, expect, it} from 'vitest'
+import type {SanityDocument} from '@sanity/client'
+import {getUniqueDocuments} from './getUniqueDocuments'
+
+describe('getUniqueDocuments', () => {
+  it('drops published documents when a drafts.* sibling exists', () => {
+    const docs: SanityDocument[] = [
+      {_id: 'drafts.post1', _type: 'post'} as SanityDocument,
+      {_id: 'post1', _type: 'post'} as SanityDocument
+    ]
+    expect(getUniqueDocuments(docs)).toEqual([{_id: 'drafts.post1', _type: 'post'}])
+  })
+
+  it('keeps published-only and draft-only ids', () => {
+    const docs: SanityDocument[] = [
+      {_id: 'onlyPub', _type: 'x'} as SanityDocument,
+      {_id: 'drafts.onlyDraft', _type: 'x'} as SanityDocument
+    ]
+    expect(getUniqueDocuments(docs)).toEqual(docs)
+  })
+
+  it('returns an empty array for an empty list', () => {
+    expect(getUniqueDocuments([])).toEqual([])
+  })
+})

--- a/src/utils/imageDprUrl.test.ts
+++ b/src/utils/imageDprUrl.test.ts
@@ -1,0 +1,42 @@
+import {afterEach, describe, expect, it} from 'vitest'
+import imageDprUrl from './imageDprUrl'
+import type {ImageAsset} from '../types'
+
+const asset = {
+  _id: 'a1',
+  _type: 'sanity.imageAsset',
+  _createdAt: '',
+  _updatedAt: '',
+  _rev: 'r1',
+  originalFilename: 'x.png',
+  size: 1,
+  mimeType: 'image/png',
+  url: 'https://cdn.test/image.png',
+  metadata: {dimensions: {width: 100, height: 100}, isOpaque: true}
+} as ImageAsset
+
+describe('imageDprUrl', () => {
+  const dpr = window.devicePixelRatio
+
+  afterEach(() => {
+    Object.defineProperty(window, 'devicePixelRatio', {value: dpr, configurable: true})
+  })
+
+  it('scales width by devicePixelRatio and sets fit=max', () => {
+    Object.defineProperty(window, 'devicePixelRatio', {value: 2, configurable: true})
+    const url = imageDprUrl(asset, {width: 400})
+    expect(url).toBe('https://cdn.test/image.png?fit=max&w=800')
+  })
+
+  it('includes height when provided, scaled by dpr', () => {
+    Object.defineProperty(window, 'devicePixelRatio', {value: 2, configurable: true})
+    const url = imageDprUrl(asset, {width: 300, height: 200})
+    expect(url).toBe('https://cdn.test/image.png?fit=max&w=600&h=400')
+  })
+
+  it('uses multiplier 1 when devicePixelRatio is missing', () => {
+    Object.defineProperty(window, 'devicePixelRatio', {value: undefined as unknown as number, configurable: true})
+    const url = imageDprUrl(asset, {width: 100})
+    expect(url).toBe('https://cdn.test/image.png?fit=max&w=100')
+  })
+})

--- a/src/utils/imageDprUrl.test.ts
+++ b/src/utils/imageDprUrl.test.ts
@@ -35,7 +35,10 @@ describe('imageDprUrl', () => {
   })
 
   it('uses multiplier 1 when devicePixelRatio is missing', () => {
-    Object.defineProperty(window, 'devicePixelRatio', {value: undefined as unknown as number, configurable: true})
+    Object.defineProperty(window, 'devicePixelRatio', {
+      value: undefined as unknown as number,
+      configurable: true
+    })
     const url = imageDprUrl(asset, {width: 100})
     expect(url).toBe('https://cdn.test/image.png?fit=max&w=100')
   })

--- a/src/utils/isSupportedAssetType.test.ts
+++ b/src/utils/isSupportedAssetType.test.ts
@@ -1,0 +1,15 @@
+import {describe, expect, it} from 'vitest'
+import {isSupportedAssetType} from './isSupportedAssetType'
+
+describe('isSupportedAssetType', () => {
+  it('returns true for file and image', () => {
+    expect(isSupportedAssetType('file')).toBe(true)
+    expect(isSupportedAssetType('image')).toBe(true)
+  })
+
+  it('returns false for unsupported or missing types', () => {
+    expect(isSupportedAssetType('video')).toBe(false)
+    expect(isSupportedAssetType('')).toBe(false)
+    expect(isSupportedAssetType(undefined)).toBe(false)
+  })
+})

--- a/src/utils/sanitizeFormData.test.ts
+++ b/src/utils/sanitizeFormData.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+
+import {describe, expect, it} from 'vitest'
+import sanitizeFormData from './sanitizeFormData'
+
+describe('sanitizeFormData', () => {
+  it('maps empty string, undefined, and empty array to null', () => {
+    expect(
+      sanitizeFormData({
+        a: '',
+        b: undefined,
+        c: []
+      })
+    ).toEqual({
+      a: null,
+      b: null,
+      c: null
+    })
+  })
+
+  it('trims non-empty strings', () => {
+    expect(sanitizeFormData({title: '  hello  '})).toEqual({title: 'hello'})
+  })
+
+  it('recurses into plain objects', () => {
+    expect(
+      sanitizeFormData({
+        opt: {
+          media: {
+            tags: []
+          }
+        }
+      })
+    ).toEqual({
+      opt: {
+        media: {
+          tags: null
+        }
+      }
+    })
+  })
+
+  it('preserves null and non-empty arrays', () => {
+    expect(
+      sanitizeFormData({
+        kept: null,
+        tags: [{_ref: 't1'}]
+      })
+    ).toEqual({
+      kept: null,
+      tags: [{_ref: 't1'}]
+    })
+  })
+
+  it('preserves numbers and booleans', () => {
+    expect(sanitizeFormData({n: 0, ok: false})).toEqual({n: 0, ok: false})
+  })
+})

--- a/src/utils/typeGuards.test.ts
+++ b/src/utils/typeGuards.test.ts
@@ -1,0 +1,17 @@
+import {describe, expect, it} from 'vitest'
+import {isFileAsset, isImageAsset} from './typeGuards'
+import type {Asset} from '../types'
+
+describe('typeGuards', () => {
+  it('isFileAsset narrows sanity.fileAsset', () => {
+    const file = {_type: 'sanity.fileAsset'} as Asset
+    expect(isFileAsset(file)).toBe(true)
+    expect(isImageAsset(file)).toBe(false)
+  })
+
+  it('isImageAsset narrows sanity.imageAsset', () => {
+    const image = {_type: 'sanity.imageAsset'} as Asset
+    expect(isImageAsset(image)).toBe(true)
+    expect(isFileAsset(image)).toBe(false)
+  })
+})

--- a/src/utils/uploadSanityAsset.test.ts
+++ b/src/utils/uploadSanityAsset.test.ts
@@ -1,0 +1,28 @@
+import {afterEach, describe, expect, it} from 'vitest'
+import {firstValueFrom} from 'rxjs'
+import {hashFile$} from './uploadSanityAsset'
+
+describe('hashFile$', () => {
+  const cryptoRef = globalThis.crypto
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'crypto', {
+      value: cryptoRef,
+      configurable: true,
+      writable: true
+    })
+  })
+
+  it('errors when Web Crypto is unavailable', async () => {
+    Object.defineProperty(globalThis, 'crypto', {
+      value: undefined,
+      configurable: true,
+      writable: true
+    })
+
+    await expect(firstValueFrom(hashFile$(new File(['x'], 'blob.bin')))).rejects.toMatchObject({
+      message: expect.stringMatching(/secure contexts/i),
+      statusCode: 500
+    })
+  })
+})

--- a/src/utils/withMaxConcurrency.test.ts
+++ b/src/utils/withMaxConcurrency.test.ts
@@ -1,0 +1,42 @@
+import {describe, expect, it} from 'vitest'
+import {Observable, firstValueFrom} from 'rxjs'
+import {createThrottler, withMaxConcurrency} from './withMaxConcurrency'
+
+describe('createThrottler', () => {
+  it('never runs more observables concurrently than the limit', async () => {
+    let active = 0
+    let maxActive = 0
+    const request = createThrottler(2)
+
+    const mk = () =>
+      new Observable<number>(sub => {
+        active++
+        maxActive = Math.max(maxActive, active)
+        queueMicrotask(() => {
+          active--
+          sub.next(1)
+          sub.complete()
+        })
+      })
+
+    await Promise.all([
+      firstValueFrom(request(mk())),
+      firstValueFrom(request(mk())),
+      firstValueFrom(request(mk()))
+    ])
+
+    expect(maxActive).toBe(2)
+  })
+})
+
+describe('withMaxConcurrency', () => {
+  it('wraps a function so each call returns a single-value observable', async () => {
+    const fn = (n: number) =>
+      new Observable<number>(sub => {
+        sub.next(n)
+        sub.complete()
+      })
+    const wrapped = withMaxConcurrency(fn, 4)
+    await expect(firstValueFrom(wrapped(7))).resolves.toBe(7)
+  })
+})

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -8,6 +8,7 @@
     "./src/**/*.test.ts",
     "./src/**/*.test.tsx",
     "./vitest.config.ts",
-    "./vitest.setup.ts"
+    "./vitest.setup.ts",
+    "./tsconfig.vitest.json"
   ]
 }

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -4,7 +4,10 @@
   "exclude": [
     "./src/**/__fixtures__",
     "./src/**/__mocks__",
+    "./src/**/__tests__",
     "./src/**/*.test.ts",
-    "./src/**/*.test.tsx"
+    "./src/**/*.test.tsx",
+    "./vitest.config.ts",
+    "./vitest.setup.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "./tsconfig.settings",
   "include": ["./src", "./package.config.ts"],
+  "exclude": [
+    "./src/**/*.test.ts",
+    "./src/**/*.test.tsx",
+    "./src/**/__tests__"
+  ],
   "compilerOptions": {
     "rootDir": "."
   }

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -4,7 +4,6 @@
     "rootDir": ".",
     "outDir": "dist",
     "noPropertyAccessFromIndexSignature": false,
-    "noUncheckedIndexedAccess": false,
-    "types": ["node", "@testing-library/jest-dom"]
+    "noUncheckedIndexedAccess": false
   }
 }

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -4,6 +4,7 @@
     "rootDir": ".",
     "outDir": "dist",
     "noPropertyAccessFromIndexSignature": false,
-    "noUncheckedIndexedAccess": false
+    "noUncheckedIndexedAccess": false,
+    "types": ["node", "@testing-library/jest-dom"]
   }
 }

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./src/types/**/*.d.ts",
+    "./src/**/*.test.ts",
+    "./src/**/*.test.tsx",
+    "./src/__tests__/**/*.ts",
+    "./src/__tests__/**/*.tsx",
+    "./vitest.config.ts",
+    "./vitest.setup.ts"
+  ],
+  "exclude": []
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  esbuild: {
+    jsx: 'automatic'
+  },
+  test: {
+    environment: 'jsdom',
+    globals: false,
+    include: ['src/**/*.test.{ts,tsx}'],
+    setupFiles: ['./vitest.setup.ts'],
+    passWithNoTests: false,
+    css: true
+  }
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom/vitest'
+import {vi} from 'vitest'
+
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  })
+}


### PR DESCRIPTION
## Summary

Introduces a **Vitest** setup and a first wave of **unit and integration-style tests** across Redux modules, utilities, and key Studio UI components. Shared **test fixtures** (mock Sanity client, epic store helper, RTL providers) keep epics and components consistent to exercise.

## Tooling and configuration

- **Vitest**: `vitest.config.ts`, `vitest.setup.ts`, and `package.json` scripts for running tests.
- **ESLint**: rules adjusted for test files (`.eslintrc.js`).
- **TypeScript**: small updates in `tsconfig.dist.json` / `tsconfig.settings.json` so the test and build toolchain align.
- **Dependencies**: `package-lock.json` / `package.json` updated for the test stack.
- **`.github/workflows/tests.yml`** — standalone **Tests** workflow 

## How to verify

Locally:

```bash
npm test
```

On GitHub, open the **Actions** tab and confirm the **Tests** workflow is green for this branch or PR.

