### PR TITLE
fix: add crossOrigin="anonymous" to Image component to fix Firefox OpaqueResponseBlocking

### DIFF
--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -11,7 +11,7 @@ type Props = {
   style?: any
 }
 
-const Image = styled.img<Props>`
+const Image = styled.img.attrs({crossOrigin: 'anonymous' as const})<Props>
   --checkerboard-color: ${props =>
     props.$scheme ? getSchemeColor(props.$scheme, 'bg2') : 'inherit'};
 


### PR DESCRIPTION
In Firefox, all thumbnail images in the media browser fail to load with
`OpaqueResponseBlocking` errors (`NS_BINDING_ABORTED` in the network panel).
This does not affect Chrome or Safari.

**Root cause:** Sanity's CDN returns `Vary: Origin` on all asset responses.
Firefox's stricter ORB implementation blocks opaque (no-cors) cross-origin
responses when the server declares `Vary: Origin`. The `Image` component
renders a plain `<img>` without a `crossOrigin` attribute, so the browser
makes a no-cors request and receives an opaque response — which Firefox blocks.

**Fix:** Adding `.attrs({crossOrigin: 'anonymous'})` to the styled component
causes the browser to include an `Origin` header with every image request.
Sanity's CDN already responds correctly with `Access-Control-Allow-Origin`
when an Origin is present, so Firefox accepts the response.

### What to review

The single change is in `src/components/Image/index.tsx` — the `Image`
styled component gains a `.attrs({crossOrigin: 'anonymous'})` call.
This affects every place in the plugin that renders image thumbnails
(card view, table view, edit dialog).

### Testing

Tested manually by loading the media browser in Firefox with and without
the change. Without it: all thumbnails blocked with NS_BINDING_ABORTED.
With it: all thumbnails load correctly. No regression observed in Chrome.

Automated testing for a browser-specific network behaviour wasn't practical.