### PR TITLE
Feature/exclude media tags from default view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [Unreleased]
+
+### Features
+
+- add `excludeTags` option (`media.tag` slug / `name.current` values): assets that reference any listed tag are omitted from Media browser and asset-picker queries; those tags are hidden in the tag sidebar and tag search facet; the asset edit dialog still lists all tags for assignment.
+
 ## [4.2.0](https://github.com/sanity-io/sanity-plugin-media/compare/v4.1.1...v4.2.0) (2026-04-23)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ export default defineConfig({
       // number - maximum file size (in bytes) that can be uploaded through the plugin interface
       directUploads: true,
       // boolean - enable / disable direct uploads through the plugin interface (default true)
+      excludeTags: ['internal', 'archived'],
+      // string[] (optional) - tag slugs (`media.tag` `name.current`). Assets that reference
+      // any of these tags are omitted from the Media browser grid and asset picker queries,
+      // and those tags are hidden in the tag sidebar and tag search facet. The asset edit
+      // dialog still lists all tags so you can assign or remove them on an open asset.
       components: {
         details: CustomDetails
         // Custom component for asset details (see below)

--- a/src/components/Browser/index.tsx
+++ b/src/components/Browser/index.tsx
@@ -7,6 +7,7 @@ import {useDispatch} from 'react-redux'
 import {type AssetSourceComponentProps, type SanityDocument} from 'sanity'
 import {TAG_DOCUMENT_NAME} from '../../constants'
 import {AssetBrowserDispatchProvider} from '../../contexts/AssetSourceDispatchContext'
+import {useToolOptions} from '../../contexts/ToolOptionsContext'
 import useVersionedClient from '../../hooks/useVersionedClient'
 import {assetsActions} from '../../modules/assets'
 import {tagsActions} from '../../modules/tags'
@@ -127,12 +128,14 @@ const BrowserContent = ({onClose}: {onClose?: AssetSourceComponentProps['onClose
 
 const Browser = (props: Props) => {
   const client = useVersionedClient()
+  const {excludeTagSlugs} = useToolOptions()
 
   return (
     <ReduxProvider
       assetType={props?.assetType}
       client={client}
       document={props?.document}
+      excludeTagSlugs={excludeTagSlugs}
       selectedAssets={props?.selectedAssets}
     >
       <AssetBrowserDispatchProvider onSelect={props?.onSelect}>

--- a/src/components/ReduxProvider/index.tsx
+++ b/src/components/ReduxProvider/index.tsx
@@ -18,6 +18,7 @@ type Props = {
   children?: ReactNode
   client: SanityClient
   document?: SanityDocument
+  excludeTagSlugs?: string[]
   selectedAssets?: AssetSourceComponentProps['selectedAssets']
 }
 
@@ -54,7 +55,8 @@ class ReduxProvider extends Component<Props> {
       preloadedState: {
         assets: {
           ...assetsInitialState,
-          assetTypes: isSupportedAssetType(props?.assetType) ? [props.assetType] : ['file', 'image']
+          assetTypes: isSupportedAssetType(props?.assetType) ? [props.assetType] : ['file', 'image'],
+          excludeTagSlugs: props.excludeTagSlugs?.length ? [...props.excludeTagSlugs] : []
         },
         debug: {
           badConnection: false,

--- a/src/components/SearchFacetTags/index.tsx
+++ b/src/components/SearchFacetTags/index.tsx
@@ -12,6 +12,7 @@ import {useColorSchemeValue} from 'sanity'
 import {operators} from '../../config/searchFacets'
 import {usePortalPopoverProps} from '../../hooks/usePortalPopoverProps'
 import useTypedSelector from '../../hooks/useTypedSelector'
+import {useToolOptions} from '../../contexts/ToolOptionsContext'
 import {searchActions} from '../../modules/search'
 import {selectTags} from '../../modules/tags'
 import {reactSelectComponents, reactSelectStyles} from '../../styled/react-select/single'
@@ -27,7 +28,12 @@ const SearchFacetTags = ({facet}: Props) => {
 
   // Redux
   const dispatch = useDispatch()
-  const tags = useTypedSelector(state => selectTags(state))
+  const {excludeTagSlugs} = useToolOptions()
+  const tagsAll = useTypedSelector(state => selectTags(state))
+  const tags =
+    excludeTagSlugs.length > 0 ?
+      tagsAll.filter(t => !excludeTagSlugs.includes(t.tag.name.current))
+    : tagsAll
   const tagsFetching = useTypedSelector(state => state.tags.fetching)
   const allTagOptions = getTagSelectOptions(tags)
 

--- a/src/components/TagView/index.tsx
+++ b/src/components/TagView/index.tsx
@@ -3,12 +3,18 @@ import {Box, Flex, Text} from '@sanity/ui'
 import useTypedSelector from '../../hooks/useTypedSelector'
 import {selectAssetsPickedLength} from '../../modules/assets'
 import {selectTags} from '../../modules/tags'
+import {useToolOptions} from '../../contexts/ToolOptionsContext'
 import TagsVirtualized from '../TagsVirtualized'
 import TagViewHeader from '../TagViewHeader'
 
 const TagView = () => {
   const numPickedAssets = useTypedSelector(selectAssetsPickedLength)
-  const tags = useTypedSelector(selectTags)
+  const {excludeTagSlugs} = useToolOptions()
+  const tagsAll = useTypedSelector(selectTags)
+  const tags =
+    excludeTagSlugs.length > 0 ?
+      tagsAll.filter(t => !excludeTagSlugs.includes(t.tag.name.current))
+    : tagsAll
   const fetching = useTypedSelector(state => state.tags.fetching)
   const fetchCount = useTypedSelector(state => state.tags.fetchCount)
   const fetchComplete = fetchCount !== -1
@@ -31,7 +37,7 @@ const TagView = () => {
         </Box>
       )}
 
-      {hasTags && <TagsVirtualized />}
+      {hasTags && <TagsVirtualized tags={tags} />}
     </Flex>
   )
 }

--- a/src/components/TagsVirtualized/index.tsx
+++ b/src/components/TagsVirtualized/index.tsx
@@ -5,7 +5,6 @@ import {Virtuoso} from 'react-virtuoso'
 import {PANEL_HEIGHT} from '../../constants'
 import useTypedSelector from '../../hooks/useTypedSelector'
 import {selectAssetsPicked} from '../../modules/assets'
-import {selectTags} from '../../modules/tags'
 import Tag from '../Tag'
 
 const VirtualRow = memo(
@@ -40,9 +39,8 @@ const VirtualRow = memo(
   }
 )
 
-const TagsVirtualized = () => {
+const TagsVirtualized = ({tags}: {tags: TagItem[]}) => {
   const assetsPicked = useTypedSelector(selectAssetsPicked)
-  const tags = useTypedSelector(selectTags)
 
   // State
   const [isScrolling, setIsScrolling] = useState(false)

--- a/src/contexts/ToolOptionsContext.tsx
+++ b/src/contexts/ToolOptionsContext.tsx
@@ -7,6 +7,7 @@ type ContextProps = {
   components: MediaToolOptions['components']
   creditLine: MediaToolOptions['creditLine']
   directUploads: MediaToolOptions['directUploads']
+  excludeTagSlugs: string[]
   locales?: Locale[]
 }
 
@@ -36,12 +37,14 @@ export const ToolOptionsProvider = ({options, children}: PropsWithChildren<Props
         excludeSources: creditLineExcludeSources
       },
       directUploads: options?.directUploads ?? true,
+      excludeTagSlugs: options?.excludeTags?.length ? [...options.excludeTags] : [],
       locales: options?.locales
     }
   }, [
     options?.creditLine?.enabled,
     options?.components,
     options?.creditLine?.excludeSources,
+    options?.excludeTags,
     options?.maximumUploadSize,
     options?.directUploads,
     options?.locales

--- a/src/modules/assets/index.ts
+++ b/src/modules/assets/index.ts
@@ -44,6 +44,7 @@ export type AssetsReducerState = {
   allIds: string[]
   assetTypes: AssetType[]
   byIds: Record<string, AssetItem>
+  excludeTagSlugs: string[]
   fetchCount: number
   fetching: boolean
   fetchingError?: HttpError
@@ -76,6 +77,7 @@ export const initialState = {
   allIds: [],
   assetTypes: [],
   byIds: {},
+  excludeTagSlugs: [],
   fetchCount: -1,
   fetching: false,
   fetchingError: undefined,
@@ -460,6 +462,7 @@ export const assetsFetchPageIndexEpic: MyEpic = (action$, state$) =>
 
       const constructedFilter = constructFilter({
         assetTypes: state.assets.assetTypes,
+        excludeTagSlugs: state.assets.excludeTagSlugs,
         searchFacets: state.search.facets,
         searchQuery: state.search.query
       })

--- a/src/modules/uploads/index.ts
+++ b/src/modules/uploads/index.ts
@@ -231,6 +231,7 @@ export const uploadsCheckRequestEpic: MyEpic = (action$, state$, {client}) =>
 
       const constructedFilter = constructFilter({
         assetTypes: state.assets.assetTypes,
+        excludeTagSlugs: state.assets.excludeTagSlugs,
         searchFacets: state.search.facets,
         searchQuery: state.search.query
       })

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,12 @@ export type MediaToolOptions = {
   }
   directUploads?: boolean
   /**
+   * Tag slugs (`media.tag.name.current`) whose assets are omitted from the main
+   * Media browser grid (and from the tag sidebar / tag search facet). Assets may
+   * still be edited via dialogs and still appear in the asset source when relevant.
+   */
+  excludeTags?: string[]
+  /**
    * Optional locales following Sanity recommended scheme: [{ id, title }]
    * https://www.sanity.io/docs/studio/localization#k4da239411955
    */

--- a/src/utils/constructFilter.test.ts
+++ b/src/utils/constructFilter.test.ts
@@ -116,4 +116,16 @@ describe('constructFilter', () => {
 
     expect(q).not.toContain('match ')
   })
+
+  it('excludes assets tagged with any slug listed in excludeTagSlugs', () => {
+    const q = constructFilter({
+      assetTypes: ['image', 'file'],
+      excludeTagSlugs: ['internal', 'archived'],
+      searchFacets: [],
+      searchQuery: undefined
+    })
+
+    expect(q.replace(/\s+/g, ' ')).toContain('name.current in ["internal","archived"]')
+    expect(q.replace(/\s+/g, ' ')).toContain('opt.media.tags')
+  })
 })

--- a/src/utils/constructFilter.ts
+++ b/src/utils/constructFilter.ts
@@ -1,14 +1,17 @@
 import type {AssetType, SearchFacetInputProps} from '../types'
 import groq from 'groq'
 
+import {TAG_DOCUMENT_NAME} from '../constants'
 import {operators} from '../config/searchFacets'
 
 const constructFilter = ({
   assetTypes,
+  excludeTagSlugs,
   searchFacets,
   searchQuery
 }: {
   assetTypes: AssetType[]
+  excludeTagSlugs?: string[]
   searchFacets: SearchFacetInputProps[]
   searchQuery?: string
 }): string => {
@@ -20,6 +23,11 @@ const constructFilter = ({
   const baseFilter = groq`
     _type in ${JSON.stringify(documentAssetTypes)} && !(_id in path("drafts.**"))
   `
+
+  const excludeTagsFragment =
+    excludeTagSlugs?.length ?
+      groq`!(defined(opt.media.tags) && count(opt.media.tags[@._ref in *[_type == "${TAG_DOCUMENT_NAME}" && name.current in ${JSON.stringify(excludeTagSlugs)}]._id]) > 0)`
+    : undefined
 
   const searchFacetFragments = searchFacets.reduce((acc: string[], facet) => {
     if (facet.type === 'number') {
@@ -79,6 +87,7 @@ const constructFilter = ({
   const constructedQuery = [
     // Base filter
     baseFilter,
+    ...(excludeTagsFragment ? [excludeTagsFragment] : []),
     // Search query (if present)
     // NOTE: Currently this only searches direct fields on sanity.fileAsset/sanity.imageAsset and NOT referenced tags
     // It's possible to add this by adding the following line to the searchQuery, but it's quite slow

--- a/src/utils/constructFilter.ts
+++ b/src/utils/constructFilter.ts
@@ -24,9 +24,12 @@ const constructFilter = ({
     _type in ${JSON.stringify(documentAssetTypes)} && !(_id in path("drafts.**"))
   `
 
-  const excludeTagsFragment =
-    excludeTagSlugs?.length ?
-      groq`!(defined(opt.media.tags) && count(opt.media.tags[@._ref in *[_type == "${TAG_DOCUMENT_NAME}" && name.current in ${JSON.stringify(excludeTagSlugs)}]._id]) > 0)`
+  const serializedExcludeTagSlugs = excludeTagSlugs?.length
+    ? JSON.stringify(excludeTagSlugs)
+    : undefined
+
+  const excludeTagsFragment = serializedExcludeTagSlugs
+    ? groq`!(defined(opt.media.tags) && count(opt.media.tags[@._ref in *[_type == "${TAG_DOCUMENT_NAME}" && name.current in ${serializedExcludeTagSlugs}]._id]) > 0)`
     : undefined
 
   const searchFacetFragments = searchFacets.reduce((acc: string[], facet) => {


### PR DESCRIPTION
### Description
feat: add excludeTags option to hide specific tagged assets from Media browser

### What to review
Add media({ excludeTags: string[] }) using tag slugs (media.tag name.current).
Excluded assets are omitted from grid and asset-picker GROQ queries; matching
tags are hidden in the sidebar and tag search facet. Asset edit still lists
all tags. Wire option through ToolOptionsContext and Redux; document in README
and extend constructFilter tests.

### Testing

Testing: Added a unit test in constructFilter.test.ts for the excludeTags GROQ filter (same path used for grid/paging and upload checks). No extra UI/Redux integration tests—it’s mostly wiring around that filter.

Validation: tsc + vitest pass; spot-check in Studio with excludeTags: ['slug'] on grid, picker, sidebar/facet, and asset edit.