### PR TITLE
feat(meta): add image metadata (sanity.imageExifTags) extraction on asset upload

### DIFF
--- a/src/components/DialogAssetEdit/index.tsx
+++ b/src/components/DialogAssetEdit/index.tsx
@@ -67,8 +67,13 @@ const DialogAssetEdit = (props: Props) => {
 
   const generateDefaultValues = useCallback(
     (asset?: Asset): AssetFormData => {
+      const imageDescription =
+        asset && isImageAsset(asset)
+          ? (asset.metadata?.image?.ImageDescription as string | undefined)
+          : undefined
+
       if (locales && locales.length > 0) {
-        const makeLocaleObj = (field?: Record<string, string> | string) => {
+        const makeLocaleObj = (field?: Record<string, string> | string, fallback = '') => {
           const obj: Record<string, string> = {}
           for (let i = 0; i < locales.length; i++) {
             const locale = locales[i]
@@ -79,7 +84,7 @@ const DialogAssetEdit = (props: Props) => {
               // across all languages; the user should fill in other translations manually
               obj[locale.id] = i === 0 ? field : ''
             } else {
-              obj[locale.id] = ''
+              obj[locale.id] = i === 0 ? fallback : ''
             }
           }
           return obj
@@ -87,25 +92,25 @@ const DialogAssetEdit = (props: Props) => {
         return {
           altText: makeLocaleObj(asset?.altText),
           creditLine: makeLocaleObj(asset?.creditLine),
-          description: makeLocaleObj(asset?.description),
+          description: makeLocaleObj(asset?.description, imageDescription),
           originalFilename: asset?.originalFilename || '',
           opt: {media: {tags: assetTagOptions}},
           title: makeLocaleObj(asset?.title)
         }
       }
       // Normalize: if a field is a localized object but locales are disabled, pick first non-empty value
-      const flattenField = (field: unknown): string => {
+      const flattenField = (field: unknown, fallback = ''): string => {
         if (typeof field === 'string') return field
         if (typeof field === 'object' && field !== null) {
           const values = Object.values(field as Record<string, string>)
-          return values.find(v => v) || ''
+          return values.find(v => v) || fallback
         }
-        return ''
+        return fallback
       }
       return {
         altText: flattenField(asset?.altText),
         creditLine: flattenField(asset?.creditLine),
-        description: flattenField(asset?.description),
+        description: flattenField(asset?.description, imageDescription),
         originalFilename: asset?.originalFilename || '',
         opt: {media: {tags: assetTagOptions}},
         title: flattenField(asset?.title)
@@ -172,8 +177,7 @@ const DialogAssetEdit = (props: Props) => {
   // Detect if asset has localized fields (objects) with keys not in the configured locales
   const hasOrphanedLocales = useMemo(() => {
     if (!currentAsset) return false
-    const isLocaleObj = (v: unknown) =>
-      typeof v === 'object' && v !== null && !Array.isArray(v)
+    const isLocaleObj = (v: unknown) => typeof v === 'object' && v !== null && !Array.isArray(v)
     const fields = [
       currentAsset.title,
       currentAsset.altText,

--- a/src/modules/assets/index.ts
+++ b/src/modules/assets/index.ts
@@ -245,6 +245,7 @@ const assetsSlice = createSlice({
               metadata {
                 dimensions,
                 exif,
+                image,
                 isOpaque,
               },
               mimeType,

--- a/src/utils/uploadSanityAsset.ts
+++ b/src/utils/uploadSanityAsset.ts
@@ -74,7 +74,7 @@ const uploadSanityAsset$ = (
       // Begin upload if no existing asset found
       return client.observable.assets
         .upload(assetType, file, {
-          extract: ['blurhash', 'exif', 'location', 'lqip', 'palette'],
+          extract: ['blurhash', 'exif', 'image', 'location', 'lqip', 'palette'],
           preserveFilename: true
         })
         .pipe(


### PR DESCRIPTION
… asset upload

### Description

**Problem:** metadata.image ([sanity.imageExifTags](https://www.sanity.io/docs/apis-and-sdks/image-metadata#k80321c79f632)) is never extracted because 'image' is missing from the extract array, and the GROQ projection also omits it — so even assets that already have the data won't return it.

**Changes:** 
1. added 'image' to both the upload extract list and the GROQ query.
2. auto-populated 'image::ImageDescription' metadata into DialogAssetEdit description as fallback (only for image assets)

**Why it matters:** [sanity.imageExifTags](https://www.sanity.io/docs/apis-and-sdks/image-metadata#k80321c79f632) provides main image EXIF tags (title, description, keywords, copyright) that most photo-related workflows rely on for auto-populating asset metadata.

### What to review

`utils/uploadSanityAsset` does not strip away this data so it can be used in Sanity Studio.

### Testing

'ImageDescription' meta could seen as auto-populated input Description (when available)

Rest of image meta could be logged and used to pre-populate or display data in Studio, 
or even partially added into Media Plugin `components/AssetMetadata` (next to exif)

<img width="598" height="479" alt="Screenshot 2026-05-12 at 17 59 35" src="https://github.com/user-attachments/assets/001e3b17-154d-4042-8a30-7f77704d12f1" />
<img width="724" height="568" alt="Screenshot 2026-05-12 at 18 00 15" src="https://github.com/user-attachments/assets/193a6259-dfa7-41a9-9778-9789cd3fcaf0" />


